### PR TITLE
Add unit tests for DelegationGrantStore and message flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@ BlocksSecret__AllowedCorsOrigins=https://app.example.com,https://admin.example.c
 ASPNETCORE_ENVIRONMENT=Development
 HTTP1_PORT=5000
 HTTP2_PORT=5001
+
+# Delegated access: IAM's INTERNAL base URL, used to discover the token endpoint.
+# One of BLOCKS_IAM_BASE_URL or BLOCKS_IAM_TOKEN_ENDPOINT is required -- the host will not start
+# without it. Never point these at the public host.
+BLOCKS_IAM_BASE_URL=http://blocks-iam:8080
+# BLOCKS_IAM_TOKEN_ENDPOINT=http://blocks-iam:8080/api/oidc/token

--- a/README.md
+++ b/README.md
@@ -139,6 +139,103 @@ public sealed class DemoPublisher
 }
 ```
 
+## Delegated access: calling another service as the originating user
+
+A worker has identity but no credential — `BlocksContext` arrives over the bus with `OAuthToken`
+blanked. Delegated access closes that gap without passing a token through the message.
+
+At send time, while a validated user token is still in scope, the message client writes a short
+**delegation grant** to Redis and puts its opaque id in the `DelegationGrant` header. The worker
+redeems that id at IAM (RFC 8693 token exchange) for a normal, ~5-minute Blocks access token
+carrying the original user's tenant, organization, roles and permissions. A long job can redeem as
+often as it needs; nothing rotates, so retries are safe.
+
+**Sending is automatic.** Any `SendToConsumerAsync` / `SendToMassConsumerAsync` made inside an
+authenticated request creates the grant for you. With no authenticated user, no grant is created and
+the header is omitted — it fails closed.
+
+```csharp
+// Optional: cap the grant's lifetime. Defaults to 2 days.
+await _messageClient.SendToConsumerAsync(new ConsumerMessage<EmailRequested>
+{
+    ConsumerName = "email_queue",
+    Payload = payload,
+    DelegationTtl = TimeSpan.FromHours(6),
+});
+```
+
+**Using the token is explicit, per call.** Ask for the headers and pass them to `IHttpService`, so
+the call is still traced:
+
+```csharp
+public sealed class SendEmailConsumer : IConsumer<EmailRequested>
+{
+    private readonly IHttpService _httpService;
+    private readonly IDelegatedTokenProvider _delegatedToken;
+
+    public SendEmailConsumer(IHttpService httpService, IDelegatedTokenProvider delegatedToken)
+    {
+        _httpService = httpService;
+        _delegatedToken = delegatedToken;
+    }
+
+    public async Task Consume(EmailRequested message)
+    {
+        // Adds Authorization: Bearer <token> and x-blocks-key. Merges with headers you pass in;
+        // your own Authorization always wins.
+        var headers = await _delegatedToken.GetAuthorizationHeadersAsync();
+
+        var (result, error) = await _httpService.Post<SendResult>(
+            message, "http://blocks-logic:8080/api/email/send", headers: headers);
+    }
+}
+```
+
+Nothing is attached implicitly, by design: a worker calling a third party must not hand it a Blocks
+credential. Call without these headers and no credential is sent.
+
+The token is cached per grant and single-flighted, so fifty concurrent calls cost one exchange, and a
+four-hour job costs one exchange per token lifetime rather than one per call.
+
+**Outside a worker** — in an API request — there is no grant, and
+`GetAuthorizationHeadersAsync()` returns your headers unchanged. Delegation solves the worker
+problem specifically.
+
+### Required configuration
+
+Genesis resolves IAM's token endpoint by OIDC discovery and **never hardcodes the path**, because
+`ApiRouting:Prefix` can rewrite it. Set at least one of these, or **the host fails to start**:
+
+| Setting | Meaning |
+|---|---|
+| `BLOCKS_IAM_BASE_URL` | Preferred. Used for `GET {base}/{tenantId}/.well-known/openid-configuration`. |
+| `BLOCKS_IAM_TOKEN_ENDPOINT` | Fallback: the **complete** endpoint URL, e.g. `http://blocks-iam:8080/api/oidc/token`. Not a base, not a template. |
+
+Both resolve in this order: **environment variable → `FrontendRuntime` section → configuration root.**
+`FrontendRuntime` is checked before the root because that is where Blocks services keep runtime
+settings, so this is the normal place to put them in `appsettings.json`:
+
+```json
+{
+  "FrontendRuntime": {
+    "BLOCKS_IAM_BASE_URL": "http://blocks-iam:8080"
+  }
+}
+```
+
+A bare root-level `"BLOCKS_IAM_BASE_URL"` also works. **Point them at IAM's internal address, never
+the public host** — that is what keeps the exchange off public ingress.
+
+### Operational notes
+
+- The grant id is a bearer credential. It is never logged, tagged on an `Activity`, or put in
+  Baggage — keep it that way, and audit dead-letter tooling that captures message headers.
+- Restrict Redis writes to `delegation:*` to the Genesis delegation component; write access there is
+  impersonation authority.
+- The exchange signature has a ±60s clock window, so **NTP must be correct** on worker and IAM nodes.
+- A grant is deleted only after a successful settle (business op → ACK → DEL). A failed run keeps its
+  grant so the redelivery still works; the absolute TTL is the backstop.
+
 ## Public API surface
 
 All types below live in the `Blocks.Genesis` namespace.
@@ -152,6 +249,7 @@ All types below live in the `Blocks.Genesis` namespace.
 | Data | `IDbContextProvider` (MongoDB collections per tenant), `ICacheClient` (Redis strings, hashes, pub/sub) |
 | Tenancy | `ITenants`, `Tenant`, `TenantValidationMiddleware` |
 | HTTP and gRPC | `IHttpService` (typed HTTP calls with header propagation), `IGrpcClientFactory`, `GrpcClientInterceptor`, `GrpcServerInterceptor` |
+| Delegated access | `IDelegatedTokenProvider` (`GetAuthorizationHeadersAsync`, `GetTokenAsync`), `DelegatedTokenContext`, `IDelegationGrantStore`, `IDelegationGrantFactory`, `IDelegationTokenEndpointResolver`, `DelegationSignature`, `DelegationConstants`, `DelegationGrantRecord` |
 | Utilities | `ICryptoService` (SHA-256 hash, HMAC-SHA256, constant-time comparison), `IVault`, `VaultType` |
 | Middleware | `GlobalExceptionHandlerMiddleware`, `RequestMetricsMiddleware`, `TenantValidationMiddleware` |
 | API docs | `BlocksApiDocExtensions.AddBlocksSwagger`, `BlocksSwaggerOptions` |
@@ -188,6 +286,8 @@ With Azure Key Vault the same names are used without the `BlocksSecret__` prefix
 | `ServiceBusConnectionString` | none | When set, logs and traces are forwarded to the LMT pipeline over the message bus instead of being written directly to MongoDB |
 | `MaxRetries` | `3` | LMT send retry attempts (also settable as `Lmt:MaxRetries` in `appsettings.json`) |
 | `MaxFailedBatches` | `100` | LMT failed-batch queue size (also settable as `Lmt:MaxFailedBatches`) |
+| `BLOCKS_IAM_BASE_URL` | none | IAM's **internal** base URL, used to discover the token endpoint for delegated access. Required unless `BLOCKS_IAM_TOKEN_ENDPOINT` is set — **the host will not start without one of the two** |
+| `BLOCKS_IAM_TOKEN_ENDPOINT` | none | Fallback for the above: the complete token endpoint URL, e.g. `http://blocks-iam:8080/api/oidc/token` |
 
 `src/Genesis/setup_env.sh` exports placeholder values for all core secrets for a local session (`source setup_env.sh`), and `.env.example` at the repository root shows a working local configuration for the docker-compose services.
 

--- a/src/Genesis/Configuration/ApplicationConfigurations.cs
+++ b/src/Genesis/Configuration/ApplicationConfigurations.cs
@@ -148,6 +148,10 @@ public static class ApplicationConfigurations
 
         services.AddSingleton<IHttpService, HttpService>();
 
+        // Delegated access must be registered before the message client: the client depends on
+        // IDelegationGrantFactory to stamp the DelegationGrant header at send time.
+        services.AddBlocksDelegation();
+
         ConfigureMessageClient(services, messageConfiguration).GetAwaiter().GetResult();
 
         services.AddHttpContextAccessor();

--- a/src/Genesis/Delegation/DelegatedTokenContext.cs
+++ b/src/Genesis/Delegation/DelegatedTokenContext.cs
@@ -1,0 +1,31 @@
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Ambient holder for the delegation grant id the current unit of work may redeem.
+/// <para>
+/// The worker sets this from the <c>DelegationGrant</c> message header before dispatching to the
+/// handler, and clears it after the message settles. The value is a bearer credential: it must
+/// never be logged, set as an <c>Activity</c> tag, or placed in Baggage.
+/// </para>
+/// </summary>
+public static class DelegatedTokenContext
+{
+    private static readonly AsyncLocal<string?> _current = new();
+
+    /// <summary>The grant id for the current logical flow, or <c>null</c> when there is none.</summary>
+    public static string? Current => _current.Value;
+
+    /// <summary>True when a grant id is present.</summary>
+    public static bool HasGrant => !string.IsNullOrWhiteSpace(_current.Value);
+
+    /// <summary>
+    /// Sets the grant id. A malformed value is treated as absent so the flow fails closed
+    /// rather than sending garbage to the exchange endpoint.
+    /// </summary>
+    public static void Set(string? delegationGrantId)
+    {
+        _current.Value = DelegationGrantStore.IsWellFormed(delegationGrantId) ? delegationGrantId : null;
+    }
+
+    public static void Clear() => _current.Value = null;
+}

--- a/src/Genesis/Delegation/DelegatedTokenProvider.cs
+++ b/src/Genesis/Delegation/DelegatedTokenProvider.cs
@@ -1,0 +1,333 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Exchanges a delegation grant for a short-lived Blocks access token, caching the result per
+/// grant id so a job that runs for hours performs one exchange per token lifetime rather than
+/// one per outbound call.
+/// <para>
+/// <b>Tenant comes from <see cref="BlocksContext"/>, never from a raw header.</b> In a worker it
+/// was populated from the message <c>SecurityContext</c>; in an API request it comes from the
+/// validated token.
+/// </para>
+/// <para>
+/// The <see cref="Lazy{T}"/> wrapper is what gives single-flight: concurrent callers on one grant
+/// observe the same in-flight exchange. The dictionary does not evict on its own, so entries are
+/// removed when a message settles and swept opportunistically.
+/// </para>
+/// </summary>
+public sealed class DelegatedTokenProvider : IDelegatedTokenProvider
+{
+    private sealed record CachedToken(string AccessToken, DateTimeOffset ExpiresAt)
+    {
+        /// <summary>Servable until one minute before expiry.</summary>
+        public bool IsUsable(DateTimeOffset now) => now < ExpiresAt - DelegationConstants.TokenRenewalMargin;
+    }
+
+    private const int SweepInterval = 64;
+
+    private readonly ConcurrentDictionary<string, Lazy<Task<CachedToken?>>> _cache = new(StringComparer.Ordinal);
+    private readonly ITenants _tenants;
+    private readonly IDelegationTokenEndpointResolver _endpointResolver;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<DelegatedTokenProvider> _logger;
+    private readonly ActivitySource? _activitySource;
+    private readonly TimeProvider _timeProvider;
+
+    private int _callCount;
+
+    public DelegatedTokenProvider(
+        ITenants tenants,
+        IDelegationTokenEndpointResolver endpointResolver,
+        IHttpClientFactory httpClientFactory,
+        ILogger<DelegatedTokenProvider> logger,
+        ActivitySource? activitySource = null,
+        TimeProvider? timeProvider = null)
+    {
+        _tenants = tenants;
+        _endpointResolver = endpointResolver;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _activitySource = activitySource;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<string?> GetTokenAsync(CancellationToken ct = default)
+    {
+        var delegationId = DelegatedTokenContext.Current;
+        if (string.IsNullOrWhiteSpace(delegationId)) return null;
+
+        var tenantId = BlocksContext.GetContext()?.TenantId;
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            DelegatedTokenProviderLog.NoTenantInContext(_logger);
+            return null;
+        }
+
+        if (Interlocked.Increment(ref _callCount) % SweepInterval == 0)
+        {
+            SweepExpired();
+        }
+
+        // At most one retry, and only to replace a cached entry that has aged out. An entry this
+        // call created and then found unusable is a rejection from IAM: retrying it immediately
+        // would double the load on the token endpoint for every failure.
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            var createdHere = false;
+
+            var entry = _cache.GetOrAdd(
+                delegationId!,
+                _ =>
+                {
+                    createdHere = true;
+
+                    // The exchange is shared work, so it deliberately does not take the first
+                    // caller's token: one caller giving up must not cancel it for the other
+                    // forty-nine. The HTTP client timeout is what bounds it.
+                    return new Lazy<Task<CachedToken?>>(
+                        () => ExchangeAsync(tenantId!, delegationId!, CancellationToken.None),
+                        LazyThreadSafetyMode.ExecutionAndPublication);
+                });
+
+            CachedToken? token;
+            try
+            {
+                // Each caller waits under its own token instead.
+                token = await entry.Value.WaitAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // This caller gave up. The shared exchange stays in flight for everyone else, so
+                // the entry must survive.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // A faulted Lazy caches its exception forever, so drop the entry and let the next call retry.
+                RemoveIf(delegationId!, entry);
+                DelegatedTokenProviderLog.ExchangeFailed(_logger, ex);
+                return null;
+            }
+
+            if (token is not null && token.IsUsable(_timeProvider.GetUtcNow()))
+            {
+                return token.AccessToken;
+            }
+
+            RemoveIf(delegationId!, entry);
+
+            if (createdHere)
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    public async Task<Dictionary<string, string>> GetAuthorizationHeadersAsync(
+        Dictionary<string, string>? existingHeaders = null,
+        CancellationToken ct = default)
+    {
+        // Copy: the caller's dictionary is theirs and may be reused across requests.
+        var headers = existingHeaders is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(existingHeaders, StringComparer.OrdinalIgnoreCase);
+
+        // A caller-supplied credential always wins.
+        if (headers.ContainsKey(BlocksConstants.AuthorizationHeaderName))
+        {
+            return headers;
+        }
+
+        var token = await GetTokenAsync(ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return headers;
+        }
+
+        headers[BlocksConstants.AuthorizationHeaderName] = BlocksConstants.Bearer + token;
+
+        // Set explicitly: HttpService only forwards headers the caller passed in.
+        var tenantId = BlocksContext.GetContext()?.TenantId;
+        if (!string.IsNullOrWhiteSpace(tenantId) && !headers.ContainsKey(BlocksConstants.BlocksKey))
+        {
+            headers[BlocksConstants.BlocksKey] = tenantId!;
+        }
+
+        return headers;
+    }
+
+    public void Invalidate(string? delegationGrantId)
+    {
+        if (string.IsNullOrWhiteSpace(delegationGrantId)) return;
+        _cache.TryRemove(delegationGrantId!, out _);
+    }
+
+    private async Task<CachedToken?> ExchangeAsync(string tenantId, string delegationId, CancellationToken ct)
+    {
+        // This is the one outbound call that does not go through HttpService -- it cannot, or
+        // redeeming a grant would recurse into redeeming a grant -- so it carries its own span.
+        // Exchange latency and rate are the metrics that tell you whether delegation is healthy.
+        using var activity = _activitySource?.StartActivity(
+            "blocks.delegation.token_exchange",
+            ActivityKind.Client,
+            Activity.Current?.Context ?? default);
+
+        activity?.SetTag("blocks.tenant_id", tenantId);
+
+        var salt = _tenants.GetTenantByID(tenantId)?.TenantSalt;
+        if (string.IsNullOrWhiteSpace(salt))
+        {
+            DelegatedTokenProviderLog.NoTenantSalt(_logger, tenantId);
+            return null;
+        }
+
+        var endpoint = await _endpointResolver.GetTokenEndpointAsync(tenantId, ct).ConfigureAwait(false);
+
+        var ts = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        var nonce = DelegationSignature.NewNonce();
+        var signature = DelegationSignature.Compute(tenantId, delegationId, nonce, ts, salt!);
+
+        var form = new Dictionary<string, string>
+        {
+            ["grant_type"] = DelegationConstants.TokenExchangeGrantType,
+            ["subject_token"] = delegationId,
+            ["subject_token_type"] = DelegationConstants.DelegationGrantTokenType,
+            ["nonce"] = nonce,
+            ["ts"] = ts.ToString(),
+            ["sig"] = signature
+        };
+
+        using var client = _httpClientFactory.CreateClient(DelegationConstants.ExchangeHttpClientName);
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new FormUrlEncodedContent(form)
+        };
+        request.Headers.TryAddWithoutValidation(BlocksConstants.BlocksKey, tenantId);
+
+        using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        activity?.SetTag("http.response.status_code", (int)response.StatusCode);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // The OAuth error code is safe to log and tag. The grant id is neither.
+            var error = ReadErrorCode(body);
+            activity?.SetTag("blocks.oauth_error", error);
+            activity?.SetStatus(ActivityStatusCode.Error, error);
+
+            DelegatedTokenProviderLog.ExchangeRejected(_logger, (int)response.StatusCode, error);
+            return null;
+        }
+
+        activity?.SetStatus(ActivityStatusCode.Ok);
+        return ReadToken(body);
+    }
+
+    private CachedToken? ReadToken(string body)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            var root = document.RootElement;
+
+            var accessToken = ReadString(root, "access_token") ?? ReadString(root, "accessToken") ?? ReadString(root, "AccessToken");
+            if (string.IsNullOrWhiteSpace(accessToken)) return null;
+
+            var expiresIn = ReadInt(root, "expires_in") ?? ReadInt(root, "expiresIn") ?? ReadInt(root, "ExpiresIn") ?? 0;
+            if (expiresIn <= 0)
+            {
+                // A response with no lifetime gets a deliberately short one: twice the renewal
+                // margin, so it is servable for the margin's length and then refetched. Trusting
+                // it for longer would risk presenting a token IAM has already expired.
+                expiresIn = (int)DelegationConstants.TokenRenewalMargin.TotalSeconds * 2;
+            }
+
+            return new CachedToken(accessToken!, _timeProvider.GetUtcNow().AddSeconds(expiresIn));
+        }
+        catch (JsonException ex)
+        {
+            DelegatedTokenProviderLog.ExchangeUnreadable(_logger, ex);
+            return null;
+        }
+    }
+
+    private void RemoveIf(string key, Lazy<Task<CachedToken?>> expected)
+    {
+        // Only remove the entry we actually observed, so a competing refresh is not discarded.
+        if (_cache.TryGetValue(key, out var current) && ReferenceEquals(current, expected))
+        {
+            _cache.TryRemove(new KeyValuePair<string, Lazy<Task<CachedToken?>>>(key, expected));
+        }
+    }
+
+    private void SweepExpired()
+    {
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var pair in _cache)
+        {
+            var lazy = pair.Value;
+            if (!lazy.IsValueCreated) continue;
+
+            var task = lazy.Value;
+            if (!task.IsCompleted) continue;
+
+            var stale = task.IsFaulted
+                || task.IsCanceled
+                || task.Result is null
+                || !task.Result!.IsUsable(now);
+
+            if (stale)
+            {
+                RemoveIf(pair.Key, lazy);
+            }
+        }
+    }
+
+    private static string? ReadString(JsonElement root, string name)
+        => root.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String ? value.GetString() : null;
+
+    private static int? ReadInt(JsonElement root, string name)
+        => root.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out var parsed)
+            ? parsed
+            : null;
+
+    private static string ReadErrorCode(string body)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(body);
+            return ReadString(document.RootElement, "error") ?? "unknown";
+        }
+        catch (JsonException)
+        {
+            return "unknown";
+        }
+    }
+}
+
+internal static partial class DelegatedTokenProviderLog
+{
+    [LoggerMessage(EventId = 7020, Level = LogLevel.Warning, Message = "A delegation grant is in scope but BlocksContext carries no tenant; no delegated token will be issued.")]
+    public static partial void NoTenantInContext(ILogger logger);
+
+    [LoggerMessage(EventId = 7021, Level = LogLevel.Error, Message = "No tenant salt available for tenant {TenantId}; cannot sign a token exchange.")]
+    public static partial void NoTenantSalt(ILogger logger, string tenantId);
+
+    [LoggerMessage(EventId = 7022, Level = LogLevel.Warning, Message = "Token exchange rejected with HTTP {StatusCode} ({Error}).")]
+    public static partial void ExchangeRejected(ILogger logger, int statusCode, string error);
+
+    [LoggerMessage(EventId = 7023, Level = LogLevel.Error, Message = "Token exchange failed.")]
+    public static partial void ExchangeFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 7024, Level = LogLevel.Error, Message = "Token exchange response could not be parsed.")]
+    public static partial void ExchangeUnreadable(ILogger logger, Exception exception);
+}

--- a/src/Genesis/Delegation/DelegationConstants.cs
+++ b/src/Genesis/Delegation/DelegationConstants.cs
@@ -1,0 +1,61 @@
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Wire-level constants for delegated access (RFC 8693 token exchange).
+/// These values are part of the cross-SDK contract: blocks-genesis-py must
+/// match them byte for byte.
+/// </summary>
+public static class DelegationConstants
+{
+    /// <summary>Message header (ApplicationProperties / AMQP header) carrying the opaque grant id.</summary>
+    public const string DelegationGrantHeader = "DelegationGrant";
+
+    /// <summary>Redis key prefix for the grant record.</summary>
+    public const string GrantKeyPrefix = "delegation:";
+
+    /// <summary>Redis key prefix for single-use exchange nonces.</summary>
+    public const string NonceKeyPrefix = "nonce:";
+
+    /// <summary>Redis key prefix for the per-grant redemption rate counter.</summary>
+    public const string RedemptionKeyPrefix = "redemption:";
+
+    /// <summary>Opaque grant id prefix. Ids are <c>dg_</c> + 64 lowercase hex chars.</summary>
+    public const string GrantIdPrefix = "dg_";
+
+    /// <summary>Number of cryptographically random bytes behind a grant id.</summary>
+    public const int GrantIdRandomBytes = 32;
+
+    /// <summary>Number of cryptographically random bytes behind an exchange nonce.</summary>
+    public const int NonceRandomBytes = 16;
+
+    /// <summary>RFC 8693 grant type.</summary>
+    public const string TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+    /// <summary>Blocks-specific subject token type naming the delegation grant.</summary>
+    public const string DelegationGrantTokenType = "urn:blocks:params:oauth:token-type:delegation-grant";
+
+    /// <summary>Default absolute lifetime of a grant record.</summary>
+    public static readonly TimeSpan DefaultGrantTtl = TimeSpan.FromDays(2);
+
+    /// <summary>Nonce replay-window TTL. Must be at least twice the clock window.</summary>
+    public static readonly TimeSpan NonceTtl = TimeSpan.FromSeconds(120);
+
+    /// <summary>Accepted clock skew on the <c>ts</c> field, in seconds.</summary>
+    public const int ClockWindowSeconds = 60;
+
+    /// <summary>Named <see cref="HttpClient"/> used for the exchange call. Deliberately has no delegated-token handler.</summary>
+    public const string ExchangeHttpClientName = "blocks-delegation-exchange";
+
+    /// <summary>How long before a token's <c>exp</c> a cached entry stops being served.</summary>
+    public static readonly TimeSpan TokenRenewalMargin = TimeSpan.FromMinutes(1);
+
+    // Configuration keys. Resolution order for both is
+    // environment variable -> configuration root -> FrontendRuntime section.
+    public const string IamBaseUrlKey = "BLOCKS_IAM_BASE_URL";
+    public const string IamTokenEndpointKey = "BLOCKS_IAM_TOKEN_ENDPOINT";
+    public const string FrontendRuntimeSection = "FrontendRuntime";
+
+    /// <summary>Builds the pipe-delimited signature input. Exact field order, no whitespace.</summary>
+    public static string BuildSignatureInput(string tenantId, string delegationId, string nonce, long ts)
+        => $"{tenantId}|{delegationId}|{nonce}|{ts}";
+}

--- a/src/Genesis/Delegation/DelegationGrantFactory.cs
+++ b/src/Genesis/Delegation/DelegationGrantFactory.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.Logging;
+using System.Security.Claims;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Builds the grant that a send attaches to a message. Shared by the Azure and RabbitMQ clients so
+/// both produce byte-identical headers.
+/// </summary>
+public interface IDelegationGrantFactory
+{
+    /// <summary>
+    /// Creates a grant for the message about to be sent, or returns <c>null</c> when the current
+    /// flow has no authenticated user to delegate. One grant per logical message; never reused.
+    /// </summary>
+    Task<string?> CreateForSendAsync(TimeSpan? ttl = null);
+}
+
+/// <summary>
+/// <para>
+/// <c>token_version</c> and <c>security_stamp</c> are read straight off <c>HttpContext.User</c>
+/// claims — they are not on <see cref="BlocksContext"/> — so a send costs no extra I/O.
+/// </para>
+/// <para>
+/// A worker-originated send (chained delegation) has no <c>HttpContext</c>. There the two values
+/// are carried forward from the grant the worker is already holding.
+/// </para>
+/// <para>
+/// With no authenticated user in context there is no grant and the header is omitted: the flow
+/// fails closed rather than minting a token nobody asked for.
+/// </para>
+/// </summary>
+public sealed class DelegationGrantFactory : IDelegationGrantFactory
+{
+    public const string TokenVersionClaim = "token_version";
+    public const string SecurityStampClaim = "security_stamp";
+
+    private readonly IDelegationGrantStore _grantStore;
+    private readonly ILogger<DelegationGrantFactory> _logger;
+
+    public DelegationGrantFactory(IDelegationGrantStore grantStore, ILogger<DelegationGrantFactory> logger)
+    {
+        _grantStore = grantStore;
+        _logger = logger;
+    }
+
+    public async Task<string?> CreateForSendAsync(TimeSpan? ttl = null)
+    {
+        var context = BlocksContext.GetContext();
+
+        if (context is null
+            || !context.IsAuthenticated
+            || string.IsNullOrWhiteSpace(context.TenantId)
+            || string.IsNullOrWhiteSpace(context.UserId))
+        {
+            return null;
+        }
+
+        var (tokenVersion, securityStamp) = ReadFromHttpUser();
+
+        if (string.IsNullOrWhiteSpace(tokenVersion) && string.IsNullOrWhiteSpace(securityStamp))
+        {
+            (tokenVersion, securityStamp) = await ReadFromHeldGrantAsync(context.TenantId).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrWhiteSpace(tokenVersion) || string.IsNullOrWhiteSpace(securityStamp))
+        {
+            // A grant without these cannot be redeemed: IAM compares both against the tenant DB.
+            DelegationGrantFactoryLog.NoVersionMaterial(_logger);
+            return null;
+        }
+
+        try
+        {
+            return await _grantStore.CreateAsync(context, tokenVersion!, securityStamp!, ttl).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A send must not fail because delegation could not be set up. The message still goes
+            // out, just without user context downstream.
+            DelegationGrantFactoryLog.CreateFailed(_logger, ex);
+            return null;
+        }
+    }
+
+    private static (string? TokenVersion, string? SecurityStamp) ReadFromHttpUser()
+    {
+        try
+        {
+            if (BlocksHttpContextAccessor.Instance?.HttpContext?.User?.Identity is not ClaimsIdentity identity
+                || !identity.IsAuthenticated)
+            {
+                return (null, null);
+            }
+
+            return (identity.FindFirst(TokenVersionClaim)?.Value, identity.FindFirst(SecurityStampClaim)?.Value);
+        }
+        catch
+        {
+            return (null, null);
+        }
+    }
+
+    private async Task<(string? TokenVersion, string? SecurityStamp)> ReadFromHeldGrantAsync(string tenantId)
+    {
+        var heldGrantId = DelegatedTokenContext.Current;
+        if (string.IsNullOrWhiteSpace(heldGrantId)) return (null, null);
+
+        var record = await _grantStore.GetAsync(heldGrantId!).ConfigureAwait(false);
+        if (record is null) return (null, null);
+
+        if (!string.Equals(record.TenantId, tenantId, StringComparison.Ordinal))
+        {
+            DelegationGrantFactoryLog.HeldGrantTenantMismatch(_logger);
+            return (null, null);
+        }
+
+        return (record.TokenVersion, record.SecurityStamp);
+    }
+}
+
+internal static partial class DelegationGrantFactoryLog
+{
+    [LoggerMessage(EventId = 7030, Level = LogLevel.Debug, Message = "No token_version/security_stamp available for the current flow; sending without a delegation grant.")]
+    public static partial void NoVersionMaterial(ILogger logger);
+
+    [LoggerMessage(EventId = 7031, Level = LogLevel.Warning, Message = "The held delegation grant belongs to a different tenant than the current context; not chaining it.")]
+    public static partial void HeldGrantTenantMismatch(ILogger logger);
+
+    [LoggerMessage(EventId = 7032, Level = LogLevel.Error, Message = "Could not create a delegation grant; the message is sent without one.")]
+    public static partial void CreateFailed(ILogger logger, Exception exception);
+}

--- a/src/Genesis/Delegation/DelegationGrantRecord.cs
+++ b/src/Genesis/Delegation/DelegationGrantRecord.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// The authoritative identity behind a delegation grant.
+/// <para>
+/// This record — not the message <c>SecurityContext</c> — is what IAM trusts when minting a
+/// delegated access token. Property names are the wire contract and are serialized in
+/// PascalCase so blocks-genesis-py and blocks-iam read the same JSON.
+/// </para>
+/// </summary>
+public sealed record DelegationGrantRecord
+{
+    [JsonPropertyName("TenantId")]
+    public string TenantId { get; init; } = string.Empty;
+
+    [JsonPropertyName("UserId")]
+    public string UserId { get; init; } = string.Empty;
+
+    [JsonPropertyName("OrganizationId")]
+    public string OrganizationId { get; init; } = string.Empty;
+
+    [JsonPropertyName("TokenVersion")]
+    public string TokenVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("SecurityStamp")]
+    public string SecurityStamp { get; init; } = string.Empty;
+}

--- a/src/Genesis/Delegation/DelegationGrantStore.cs
+++ b/src/Genesis/Delegation/DelegationGrantStore.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Redis-backed <see cref="IDelegationGrantStore"/>.
+/// <para>
+/// The record is written with its absolute TTL in a single call, so a grant can never exist
+/// without an expiry. There is no sliding TTL, no heartbeat and no cleanup scheduler: the
+/// happy path deletes the key after the message settles, and the TTL is the backstop.
+/// </para>
+/// </summary>
+public sealed class DelegationGrantStore : IDelegationGrantStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new();
+
+    private readonly ICacheClient _cacheClient;
+    private readonly ILogger<DelegationGrantStore> _logger;
+
+    public DelegationGrantStore(ICacheClient cacheClient, ILogger<DelegationGrantStore> logger)
+    {
+        _cacheClient = cacheClient;
+        _logger = logger;
+    }
+
+    public async Task<string> CreateAsync(BlocksContext ctx, string tokenVersion, string securityStamp, TimeSpan? ttl = null)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        if (string.IsNullOrWhiteSpace(ctx.TenantId) || string.IsNullOrWhiteSpace(ctx.UserId))
+        {
+            throw new InvalidOperationException("A delegation grant requires both a tenant and an authenticated user.");
+        }
+
+        var record = new DelegationGrantRecord
+        {
+            TenantId = ctx.TenantId,
+            UserId = ctx.UserId,
+            OrganizationId = ctx.OrganizationId ?? string.Empty,
+            TokenVersion = tokenVersion ?? string.Empty,
+            SecurityStamp = securityStamp ?? string.Empty
+        };
+
+        var id = NewGrantId();
+        var lifetime = NormalizeTtl(ttl);
+
+        // Value and TTL are written in one call, so a grant can never exist without an expiry.
+        // Every argument is named: the overload must be unambiguous, not chosen for us.
+        await _cacheClient.CacheDatabase()
+            .StringSetAsync(
+                key: GrantKey(id),
+                value: JsonSerializer.Serialize(record, SerializerOptions),
+                expiry: lifetime,
+                keepTtl: false,
+                when: When.Always,
+                flags: CommandFlags.None)
+            .ConfigureAwait(false);
+
+        // The id is a bearer credential: it is never logged, tagged on an Activity, or put in Baggage.
+        DelegationGrantStoreLog.GrantCreated(_logger, record.TenantId, (long)lifetime.TotalSeconds);
+
+        return id;
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        if (!IsWellFormed(id)) return;
+
+        try
+        {
+            await _cacheClient.RemoveKeyAsync(GrantKey(id)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Removal is best effort. The absolute TTL still bounds the grant.
+            DelegationGrantStoreLog.GrantDeleteFailed(_logger, ex);
+        }
+    }
+
+    public async Task<DelegationGrantRecord?> GetAsync(string id)
+    {
+        if (!IsWellFormed(id)) return null;
+
+        var json = await _cacheClient.GetStringValueAsync(GrantKey(id)).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<DelegationGrantRecord>(json, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            DelegationGrantStoreLog.GrantUnreadable(_logger, ex);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// <c>dg_</c> + 64 lowercase hex chars from 32 cryptographically random bytes.
+    /// Never <c>Guid.NewGuid()</c> — a grant id is a bearer credential, not an identifier.
+    /// </summary>
+    public static string NewGrantId()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(DelegationConstants.GrantIdRandomBytes);
+        return DelegationConstants.GrantIdPrefix + Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    public static bool IsWellFormed(string? id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) return false;
+        if (!id.StartsWith(DelegationConstants.GrantIdPrefix, StringComparison.Ordinal)) return false;
+
+        var hex = id.AsSpan(DelegationConstants.GrantIdPrefix.Length);
+        if (hex.Length != DelegationConstants.GrantIdRandomBytes * 2) return false;
+
+        foreach (var c in hex)
+        {
+            var isLowerHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+            if (!isLowerHex) return false;
+        }
+
+        return true;
+    }
+
+    internal static string GrantKey(string id) => DelegationConstants.GrantKeyPrefix + id;
+
+    private static TimeSpan NormalizeTtl(TimeSpan? ttl)
+        => ttl is { } value && value > TimeSpan.Zero ? value : DelegationConstants.DefaultGrantTtl;
+}
+
+internal static partial class DelegationGrantStoreLog
+{
+    [LoggerMessage(EventId = 7001, Level = LogLevel.Debug, Message = "Delegation grant created for tenant {TenantId} with a {TtlSeconds}s lifetime.")]
+    public static partial void GrantCreated(ILogger logger, string tenantId, long ttlSeconds);
+
+    [LoggerMessage(EventId = 7002, Level = LogLevel.Warning, Message = "Failed to delete a delegation grant. The absolute TTL will remove it.")]
+    public static partial void GrantDeleteFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 7003, Level = LogLevel.Warning, Message = "Stored delegation grant could not be deserialized.")]
+    public static partial void GrantUnreadable(ILogger logger, Exception exception);
+}

--- a/src/Genesis/Delegation/DelegationServiceCollectionExtensions.cs
+++ b/src/Genesis/Delegation/DelegationServiceCollectionExtensions.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Registers delegated access.
+/// <para>
+/// The delegated token is attached by <c>HttpService</c>, not by a message handler on the
+/// <see cref="HttpClient"/> pipeline. Every outbound Blocks call goes through that service so it is
+/// traced, which makes it the single place that sees them all — and it keeps the token off any call
+/// that bypasses tracing.
+/// </para>
+/// <para>
+/// The exchange itself uses a separate named client, so redeeming a grant never re-enters
+/// <c>HttpService</c> and can never recurse into redeeming a grant.
+/// </para>
+/// </summary>
+public static class DelegationServiceCollectionExtensions
+{
+    public static IServiceCollection AddBlocksDelegation(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<IDelegationGrantStore, DelegationGrantStore>();
+        services.AddSingleton<IDelegationGrantFactory, DelegationGrantFactory>();
+        services.AddSingleton<IDelegationTokenEndpointResolver, DelegationTokenEndpointResolver>();
+        services.AddSingleton<IDelegatedTokenProvider, DelegatedTokenProvider>();
+
+        // The client that redeems the grant. Kept separate from anything HttpService touches.
+        services.AddHttpClient(DelegationConstants.ExchangeHttpClientName);
+
+        services.AddHostedService<DelegationStartupValidator>();
+
+        return services;
+    }
+}
+
+/// <summary>
+/// Fails the host at startup when neither <c>BLOCKS_IAM_BASE_URL</c> nor
+/// <c>BLOCKS_IAM_TOKEN_ENDPOINT</c> is configured. Never silently defaults to a guessed path.
+/// </summary>
+internal sealed class DelegationStartupValidator : IHostedService
+{
+    private readonly IDelegationTokenEndpointResolver _resolver;
+    private readonly ILogger<DelegationStartupValidator> _logger;
+
+    public DelegationStartupValidator(IDelegationTokenEndpointResolver resolver, ILogger<DelegationStartupValidator> logger)
+    {
+        _resolver = resolver;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _resolver.EnsureConfigured();
+        DelegationStartupLog.Configured(_logger);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+internal static partial class DelegationStartupLog
+{
+    [LoggerMessage(EventId = 7040, Level = LogLevel.Information, Message = "Delegated access is configured. The IAM token endpoint resolves by OIDC discovery, per tenant, on first use.")]
+    public static partial void Configured(ILogger logger);
+}

--- a/src/Genesis/Delegation/DelegationSignature.cs
+++ b/src/Genesis/Delegation/DelegationSignature.cs
@@ -1,0 +1,42 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// The signature scheme protecting a token exchange. Kept separate from the provider because it is
+/// a cross-SDK contract: blocks-genesis-py and blocks-iam must produce and verify the same bytes.
+/// </summary>
+public static class DelegationSignature
+{
+    /// <summary>
+    /// HMAC-SHA256 over the pipe-delimited input, keyed by the tenant salt (UTF-8 bytes).
+    /// Returned as lowercase hex.
+    /// </summary>
+    public static string Compute(string signatureInput, string tenantSalt)
+    {
+        ArgumentNullException.ThrowIfNull(signatureInput);
+        ArgumentNullException.ThrowIfNull(tenantSalt);
+
+        var mac = HMACSHA256.HashData(Encoding.UTF8.GetBytes(tenantSalt), Encoding.UTF8.GetBytes(signatureInput));
+        return Convert.ToHexString(mac).ToLowerInvariant();
+    }
+
+    /// <summary>Convenience overload building the input from its parts.</summary>
+    public static string Compute(string tenantId, string delegationId, string nonce, long ts, string tenantSalt)
+        => Compute(DelegationConstants.BuildSignatureInput(tenantId, delegationId, nonce, ts), tenantSalt);
+
+    /// <summary>A single-use exchange nonce: 16 cryptographically random bytes, lowercase hex.</summary>
+    public static string NewNonce()
+        => Convert.ToHexString(RandomNumberGenerator.GetBytes(DelegationConstants.NonceRandomBytes)).ToLowerInvariant();
+
+    /// <summary>Constant-time comparison of two hex signatures.</summary>
+    public static bool Verify(string expected, string? presented)
+    {
+        if (string.IsNullOrEmpty(presented) || expected.Length != presented.Length) return false;
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(expected),
+            Encoding.UTF8.GetBytes(presented));
+    }
+}

--- a/src/Genesis/Delegation/DelegationTokenEndpointResolver.cs
+++ b/src/Genesis/Delegation/DelegationTokenEndpointResolver.cs
@@ -1,0 +1,171 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Two-step resolution, per section 5.5 of the delegated-access spec.
+/// <list type="number">
+/// <item>
+/// Discovery (primary): <c>GET {BLOCKS_IAM_BASE_URL}/{tenantId}/.well-known/openid-configuration</c>
+/// and take <c>token_endpoint</c>. Survives prefix and route changes.
+/// </item>
+/// <item>
+/// <c>BLOCKS_IAM_TOKEN_ENDPOINT</c> (fallback): a complete URL, not a base and not a template,
+/// so no prefix is ever guessed.
+/// </item>
+/// </list>
+/// A successful discovery is cached per tenant. A fallback is not cached, so discovery is retried
+/// lazily on later calls. If neither is configured, startup fails.
+/// <para>
+/// <c>Tenant.JwtTokenParameters.Issuer</c> is deliberately not used as a base URL: IAM separates
+/// <c>issuer</c> from <c>apiBase</c>, and the issuer is an identifier, not a reachable API host.
+/// </para>
+/// </summary>
+public sealed class DelegationTokenEndpointResolver : IDelegationTokenEndpointResolver
+{
+    private readonly IConfiguration? _configuration;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<DelegationTokenEndpointResolver> _logger;
+
+    private readonly ConcurrentDictionary<string, string> _discovered = new(StringComparer.Ordinal);
+    private int _fallbackWarningLogged;
+
+    public DelegationTokenEndpointResolver(
+        IHttpClientFactory httpClientFactory,
+        ILogger<DelegationTokenEndpointResolver> logger,
+        IConfiguration? configuration = null)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public void EnsureConfigured()
+    {
+        if (!string.IsNullOrWhiteSpace(ResolveBaseUrl()) || !string.IsNullOrWhiteSpace(ResolveConfiguredEndpoint()))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Delegated access is unconfigured: set '{DelegationConstants.IamBaseUrlKey}' (preferred, used for OIDC " +
+            $"discovery) or '{DelegationConstants.IamTokenEndpointKey}' (a complete token endpoint URL). " +
+            "Both must point at IAM's internal address, never the public host.");
+    }
+
+    public async Task<string> GetTokenEndpointAsync(string tenantId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new InvalidOperationException("Cannot resolve the IAM token endpoint without a tenant.");
+        }
+
+        if (_discovered.TryGetValue(tenantId, out var cached))
+        {
+            return cached;
+        }
+
+        var discovered = await TryDiscoverAsync(tenantId, ct).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(discovered))
+        {
+            _discovered[tenantId] = discovered!;
+            return discovered!;
+        }
+
+        var configured = ResolveConfiguredEndpoint();
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            if (Interlocked.Exchange(ref _fallbackWarningLogged, 1) == 0)
+            {
+                DelegationEndpointLog.UsingConfiguredEndpoint(_logger, DelegationConstants.IamTokenEndpointKey);
+            }
+
+            return configured!;
+        }
+
+        throw new InvalidOperationException(
+            $"OIDC discovery failed for tenant '{tenantId}' and '{DelegationConstants.IamTokenEndpointKey}' is not " +
+            "configured. Refusing to guess the token endpoint path.");
+    }
+
+    private async Task<string?> TryDiscoverAsync(string tenantId, CancellationToken ct)
+    {
+        var baseUrl = ResolveBaseUrl();
+        if (string.IsNullOrWhiteSpace(baseUrl)) return null;
+
+        var url = $"{baseUrl!.TrimEnd('/')}/{tenantId}/.well-known/openid-configuration";
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(DelegationConstants.ExchangeHttpClientName);
+            using var response = await client.GetAsync(url, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                DelegationEndpointLog.DiscoveryFailed(_logger, (int)response.StatusCode);
+                return null;
+            }
+
+            var payload = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var document = JsonDocument.Parse(payload);
+
+            if (!document.RootElement.TryGetProperty("token_endpoint", out var endpoint))
+            {
+                DelegationEndpointLog.DiscoveryMissingEndpoint(_logger);
+                return null;
+            }
+
+            var value = endpoint.GetString();
+            return Uri.TryCreate(value, UriKind.Absolute, out _) ? value : null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            DelegationEndpointLog.DiscoveryUnreachable(_logger, ex);
+            return null;
+        }
+    }
+
+    private string? ResolveBaseUrl() => ResolveSetting(DelegationConstants.IamBaseUrlKey);
+
+    private string? ResolveConfiguredEndpoint() => ResolveSetting(DelegationConstants.IamTokenEndpointKey);
+
+    /// <summary>
+    /// Environment variable, then the <c>FrontendRuntime</c> section, then the configuration root.
+    /// <para>
+    /// <c>FrontendRuntime</c> comes before the root because that is where Blocks services put their
+    /// runtime settings — it is the expected home for these keys, not a last resort. A bare root-level
+    /// key still works, so an <c>appsettings.json</c> that sets it either way resolves.
+    /// </para>
+    /// </summary>
+    private string? ResolveSetting(string key)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        if (!string.IsNullOrWhiteSpace(value)) return value.Trim();
+
+        if (_configuration is null) return null;
+
+        value = _configuration.GetSection(DelegationConstants.FrontendRuntimeSection)[key];
+        if (!string.IsNullOrWhiteSpace(value)) return value.Trim();
+
+        value = _configuration[key];
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}
+
+internal static partial class DelegationEndpointLog
+{
+    [LoggerMessage(EventId = 7010, Level = LogLevel.Warning, Message = "OIDC discovery for the IAM token endpoint returned {StatusCode}.")]
+    public static partial void DiscoveryFailed(ILogger logger, int statusCode);
+
+    [LoggerMessage(EventId = 7011, Level = LogLevel.Warning, Message = "OIDC discovery document has no token_endpoint.")]
+    public static partial void DiscoveryMissingEndpoint(ILogger logger);
+
+    [LoggerMessage(EventId = 7012, Level = LogLevel.Warning, Message = "OIDC discovery for the IAM token endpoint was unreachable.")]
+    public static partial void DiscoveryUnreachable(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 7013, Level = LogLevel.Warning, Message = "Falling back to the configured token endpoint '{Key}'. Discovery will be retried lazily.")]
+    public static partial void UsingConfiguredEndpoint(ILogger logger, string key);
+}

--- a/src/Genesis/Delegation/IDelegatedTokenProvider.cs
+++ b/src/Genesis/Delegation/IDelegatedTokenProvider.cs
@@ -1,0 +1,34 @@
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Redeems the ambient delegation grant for a short-lived Blocks access token carrying user context.
+/// </summary>
+public interface IDelegatedTokenProvider
+{
+    /// <summary>
+    /// Returns a valid access token for the grant in <see cref="DelegatedTokenContext"/>, or
+    /// <c>null</c> when there is no grant or it can no longer be redeemed. Cached and
+    /// single-flighted per grant id, so a long job may call this as often as it likes.
+    /// </summary>
+    Task<string?> GetTokenAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Builds the headers for one outbound call: <c>Authorization: Bearer</c> plus
+    /// <c>x-blocks-key</c>. Pass the result to <c>IHttpService</c> so the call is still traced.
+    /// <para>
+    /// Delegation is opt-in per call, by design. Nothing attaches a delegated token to a request
+    /// you did not ask about — a worker calling a third party must not hand it a Blocks credential.
+    /// </para>
+    /// <para>
+    /// Returns <paramref name="existingHeaders"/> unchanged (as a copy) when there is no grant in
+    /// scope, when it cannot be redeemed, or when the caller already supplied an
+    /// <c>Authorization</c> header.
+    /// </para>
+    /// </summary>
+    Task<Dictionary<string, string>> GetAuthorizationHeadersAsync(
+        Dictionary<string, string>? existingHeaders = null,
+        CancellationToken ct = default);
+
+    /// <summary>Drops the cached token for a grant. Called when a message settles.</summary>
+    void Invalidate(string? delegationGrantId);
+}

--- a/src/Genesis/Delegation/IDelegationGrantStore.cs
+++ b/src/Genesis/Delegation/IDelegationGrantStore.cs
@@ -1,0 +1,26 @@
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Writes and removes delegation grants. A grant is created at send time, while a validated
+/// user token is still in scope, and removed after the worker has settled the message.
+/// </summary>
+public interface IDelegationGrantStore
+{
+    /// <summary>
+    /// Persists a grant and returns its opaque id (<c>dg_</c> + 64 lowercase hex chars).
+    /// </summary>
+    /// <param name="ctx">Context supplying tenant, user and organization. Must carry an authenticated user.</param>
+    /// <param name="tokenVersion">The user's <c>token_version</c> claim at send time.</param>
+    /// <param name="securityStamp">The user's <c>security_stamp</c> claim at send time.</param>
+    /// <param name="ttl">Absolute lifetime. Defaults to <see cref="DelegationConstants.DefaultGrantTtl"/>.</param>
+    Task<string> CreateAsync(BlocksContext ctx, string tokenVersion, string securityStamp, TimeSpan? ttl = null);
+
+    /// <summary>Best-effort removal after a successful settle. Never called before the ACK.</summary>
+    Task DeleteAsync(string id);
+
+    /// <summary>
+    /// Reads a grant record. Used only for chained delegation: a worker-originated send carries
+    /// <c>TokenVersion</c> and <c>SecurityStamp</c> forward from the grant it is already holding.
+    /// </summary>
+    Task<DelegationGrantRecord?> GetAsync(string id);
+}

--- a/src/Genesis/Delegation/IDelegationTokenEndpointResolver.cs
+++ b/src/Genesis/Delegation/IDelegationTokenEndpointResolver.cs
@@ -1,0 +1,18 @@
+namespace Blocks.Genesis;
+
+/// <summary>
+/// Resolves IAM's token endpoint. Callers never know the URL: route paths are rewritten by
+/// <c>ApiRoutePrefixConvention</c>, so the effective path is <c>{base}/{prefix}/oidc/token</c>
+/// and may never be hardcoded.
+/// </summary>
+public interface IDelegationTokenEndpointResolver
+{
+    /// <summary>Returns the token endpoint for a tenant, preferring OIDC discovery.</summary>
+    Task<string> GetTokenEndpointAsync(string tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Throws when neither <c>BLOCKS_IAM_BASE_URL</c> nor <c>BLOCKS_IAM_TOKEN_ENDPOINT</c> is
+    /// configured. Called at startup so a misconfigured deployment fails fast.
+    /// </summary>
+    void EnsureConfigured();
+}

--- a/src/Genesis/Message/Azure/AzureMessageClient.cs
+++ b/src/Genesis/Message/Azure/AzureMessageClient.cs
@@ -11,14 +11,17 @@ public sealed class AzureMessageClient : IMessageClient
     private readonly ServiceBusClient _client;
     private readonly ConcurrentDictionary<string, ServiceBusSender> _senders;
     private readonly ActivitySource _activitySource;
+    private readonly IDelegationGrantFactory _delegationGrantFactory;
 
     public AzureMessageClient(
         MessageConfiguration messageConfiguration,
-        ActivitySource activitySource)
+        ActivitySource activitySource,
+        IDelegationGrantFactory delegationGrantFactory)
     {
         _client = new ServiceBusClient(messageConfiguration.Connection);
         _senders = new ConcurrentDictionary<string, ServiceBusSender>();
         _activitySource = activitySource;
+        _delegationGrantFactory = delegationGrantFactory;
 
         InitializeSenders(messageConfiguration);
     }
@@ -79,6 +82,17 @@ public sealed class AzureMessageClient : IMessageClient
                 ["Baggage"] = JsonSerializer.Serialize(GetBaggageDictionary())
             }
         };
+
+        // Written while a validated user token is still in scope. SecurityContext above is context
+        // and tracing only; this grant is what carries authority. No user, no grant, no header.
+        var delegationGrant = await _delegationGrantFactory
+            .CreateForSendAsync(consumerMessage.DelegationTtl)
+            .ConfigureAwait(false);
+
+        if (!string.IsNullOrWhiteSpace(delegationGrant))
+        {
+            message.ApplicationProperties[DelegationConstants.DelegationGrantHeader] = delegationGrant;
+        }
         if (consumerMessage.ScheduledEnqueueTimeUtc is not null)
         {
             await sender.ScheduleMessageAsync(message, consumerMessage.ScheduledEnqueueTimeUtc.Value);

--- a/src/Genesis/Message/Azure/AzureMessageWorker.cs
+++ b/src/Genesis/Message/Azure/AzureMessageWorker.cs
@@ -16,16 +16,26 @@ public sealed class AzureMessageWorker : BackgroundService
     private readonly ActivitySource _activitySource;
     private ServiceBusClient _serviceBusClient;
     private readonly Consumer _consumer;
+    private readonly IDelegationGrantStore _delegationGrantStore;
+    private readonly IDelegatedTokenProvider _delegatedTokenProvider;
 
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _activeMessageRenewals = new ConcurrentDictionary<string, CancellationTokenSource>();
     public event EventHandler<AutoRenewalEventArgs> MessageProcessingStarted;
 
-    public AzureMessageWorker(ILogger<AzureMessageWorker> logger, MessageConfiguration messageConfiguration, Consumer consumer, ActivitySource activitySource)
+    public AzureMessageWorker(
+        ILogger<AzureMessageWorker> logger,
+        MessageConfiguration messageConfiguration,
+        Consumer consumer,
+        ActivitySource activitySource,
+        IDelegationGrantStore delegationGrantStore,
+        IDelegatedTokenProvider delegatedTokenProvider)
     {
         _logger = logger;
         _messageConfiguration = messageConfiguration;
         _consumer = consumer;
         _activitySource = activitySource;
+        _delegationGrantStore = delegationGrantStore;
+        _delegatedTokenProvider = delegatedTokenProvider;
 
         Initialization();
     }
@@ -146,6 +156,9 @@ public sealed class AzureMessageWorker : BackgroundService
         var tenantId = args.Message.ApplicationProperties.TryGetValue("TenantId", out var tenantIdObj) ? tenantIdObj.ToString() : "";
         var securityContextString = args.Message.ApplicationProperties.TryGetValue("SecurityContext", out var securityContextObj) ? securityContextObj.ToString() : "";
         var baggageString = args.Message.ApplicationProperties.TryGetValue("Baggage", out var baggageObj) ? baggageObj.ToString() : "";
+        var delegationGrant = args.Message.ApplicationProperties.TryGetValue(DelegationConstants.DelegationGrantHeader, out var delegationGrantObj)
+            ? delegationGrantObj?.ToString()
+            : null;
 
         try
         {
@@ -155,6 +168,9 @@ public sealed class AzureMessageWorker : BackgroundService
         {
             BlocksContext.SetContext(null);
         }
+
+        // Deliberately not tagged on the activity and not put in Baggage: the grant id is a credential.
+        DelegatedTokenContext.Set(delegationGrant);
 
         foreach (var kvp in DeserializeBaggage(baggageString))
         {
@@ -233,6 +249,10 @@ public sealed class AzureMessageWorker : BackgroundService
                 if (isProcessedSuccessfully)
                 {
                     await args.CompleteMessageAsync(args.Message).ConfigureAwait(false);
+
+                    // Order is fixed: business op -> ACK -> DEL. A grant released before the ACK
+                    // would leave a redelivery unable to mint a token.
+                    await ReleaseDelegationGrantAsync(delegationGrant).ConfigureAwait(false);
                 }
                 else
                 {
@@ -262,6 +282,19 @@ public sealed class AzureMessageWorker : BackgroundService
         }
 
         BlocksContext.ClearContext();
+        DelegatedTokenContext.Clear();
+    }
+
+    /// <summary>
+    /// Removes the grant and its cached token after a successful settle. Best effort: if this
+    /// fails, the absolute TTL still bounds the grant.
+    /// </summary>
+    private async Task ReleaseDelegationGrantAsync(string? delegationGrant)
+    {
+        if (string.IsNullOrWhiteSpace(delegationGrant)) return;
+
+        _delegatedTokenProvider.Invalidate(delegationGrant);
+        await _delegationGrantStore.DeleteAsync(delegationGrant!).ConfigureAwait(false);
     }
 
     private static Dictionary<string, string> DeserializeBaggage(string? baggageString)

--- a/src/Genesis/Message/ConsumerMessage.cs
+++ b/src/Genesis/Message/ConsumerMessage.cs
@@ -15,4 +15,10 @@ public record ConsumerMessage<T>
     }
 
     public string RoutingKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional absolute lifetime for this message's delegation grant. Defaults to two days.
+    /// Set it to cover the longest the job may legitimately take, including retries.
+    /// </summary>
+    public TimeSpan? DelegationTtl { get; init; }
 }

--- a/src/Genesis/Message/Rabbit.Mq/RabbitMessageClient.cs
+++ b/src/Genesis/Message/Rabbit.Mq/RabbitMessageClient.cs
@@ -12,6 +12,7 @@ public sealed class RabbitMessageClient : IMessageClient
     private readonly IRabbitMqService _rabbitMqService;
     private readonly MessageConfiguration _messageConfiguration;
     private readonly ActivitySource _activitySource;
+    private readonly IDelegationGrantFactory _delegationGrantFactory;
 
     private IChannel? _channel;
     private Task? _initializationTask;
@@ -21,12 +22,14 @@ public sealed class RabbitMessageClient : IMessageClient
         ILogger<RabbitMessageClient> logger,
         IRabbitMqService rabbitMqService,
         MessageConfiguration messageConfiguration,
-        ActivitySource activitySource)
+        ActivitySource activitySource,
+        IDelegationGrantFactory delegationGrantFactory)
     {
         _logger = logger;
         _rabbitMqService = rabbitMqService;
         _messageConfiguration = messageConfiguration;
         _activitySource = activitySource;
+        _delegationGrantFactory = delegationGrantFactory;
     }
 
     private async Task EnsureInitializedAsync()
@@ -104,17 +107,30 @@ public sealed class RabbitMessageClient : IMessageClient
             var messageJson = JsonSerializer.Serialize(messageBody);
             var body = Encoding.UTF8.GetBytes(messageJson);
 
+            var headers = new Dictionary<string, object>
+            {
+                ["TenantId"] = securityContext?.TenantId ?? string.Empty,
+                ["TraceId"] = activity?.TraceId.ToString() ?? string.Empty,
+                ["SpanId"] = activity?.SpanId.ToString() ?? string.Empty,
+                ["SecurityContext"] = BuildTransportContextJson(securityContext, consumerMessage.Context),
+                ["Baggage"] = JsonSerializer.Serialize(Activity.Current?.Baggage?.ToDictionary(b => b.Key, b => b.Value))
+            };
+
+            // Written while a validated user token is still in scope. SecurityContext above is context
+            // and tracing only; this grant is what carries authority. No user, no grant, no header.
+            var delegationGrant = await _delegationGrantFactory
+                .CreateForSendAsync(consumerMessage.DelegationTtl)
+                .ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(delegationGrant))
+            {
+                headers[DelegationConstants.DelegationGrantHeader] = delegationGrant;
+            }
+
             var properties = new BasicProperties
             {
                 DeliveryMode = DeliveryModes.Persistent,
-                Headers = new Dictionary<string, object>
-                {
-                    ["TenantId"] = securityContext?.TenantId ?? string.Empty,
-                    ["TraceId"] = activity?.TraceId.ToString() ?? string.Empty,
-                    ["SpanId"] = activity?.SpanId.ToString() ?? string.Empty,
-                    ["SecurityContext"] = BuildTransportContextJson(securityContext, consumerMessage.Context),
-                    ["Baggage"] = JsonSerializer.Serialize(Activity.Current?.Baggage?.ToDictionary(b => b.Key, b => b.Value))
-                }
+                Headers = headers
             };
 
             if (_messageConfiguration?.RabbitMqConfiguration?.MessageTtlSeconds > 0)

--- a/src/Genesis/Message/Rabbit.Mq/RabbitMessageWorker.cs
+++ b/src/Genesis/Message/Rabbit.Mq/RabbitMessageWorker.cs
@@ -16,6 +16,8 @@ public sealed class RabbitMessageWorker : BackgroundService
     private readonly IRabbitMqService _rabbitMqService;
     private readonly Consumer _consumer;
     private readonly ActivitySource _activitySource;
+    private readonly IDelegationGrantStore _delegationGrantStore;
+    private readonly IDelegatedTokenProvider _delegatedTokenProvider;
 
     private IChannel? _channel;
 
@@ -24,13 +26,17 @@ public sealed class RabbitMessageWorker : BackgroundService
         MessageConfiguration messageConfiguration,
         IRabbitMqService rabbitMqService,
         Consumer consumer,
-        ActivitySource activitySource)
+        ActivitySource activitySource,
+        IDelegationGrantStore delegationGrantStore,
+        IDelegatedTokenProvider delegatedTokenProvider)
     {
         _logger = logger;
         _messageConfiguration = messageConfiguration;
         _rabbitMqService = rabbitMqService;
         _consumer = consumer;
         _activitySource = activitySource;
+        _delegationGrantStore = delegationGrantStore;
+        _delegatedTokenProvider = delegatedTokenProvider;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -87,9 +93,13 @@ public sealed class RabbitMessageWorker : BackgroundService
     {
         try
         {
-            ExtractHeaders(ea.BasicProperties, out var tenantId, out var traceId, out var spanId, out var securityContext, out var baggage);
+            ExtractHeaders(ea.BasicProperties, out var tenantId, out var traceId, out var spanId, out var securityContext, out var baggage, out var delegationGrant);
 
             SetSecurityContextFromHeader(securityContext);
+
+            // Deliberately not tagged on the activity and not put in Baggage: the grant id is a credential.
+            DelegatedTokenContext.Set(delegationGrant);
+
             ApplyBaggage(baggage, tenantId);
 
             var parentContext = BuildParentActivityContext(traceId, spanId);
@@ -104,7 +114,7 @@ public sealed class RabbitMessageWorker : BackgroundService
             var body = ea.Body.ToArray();
             _logger.LogInformation("Received message for queue {Queue}", ea.RoutingKey);
 
-            await DispatchAndAckAsync(body, activity, ea);
+            await DispatchAndAckAsync(body, activity, ea, delegationGrant);
         }
         catch (Exception ex)
         {
@@ -113,8 +123,9 @@ public sealed class RabbitMessageWorker : BackgroundService
         }
         finally
         {
-            // ClearContext only resets an AsyncLocal and cannot throw.
+            // Both only reset an AsyncLocal and cannot throw.
             BlocksContext.ClearContext();
+            DelegatedTokenContext.Clear();
         }
     }
 
@@ -195,7 +206,7 @@ public sealed class RabbitMessageWorker : BackgroundService
         }
     }
 
-    private async Task DispatchAndAckAsync(byte[] body, Activity? activity, BasicDeliverEventArgs ea)
+    private async Task DispatchAndAckAsync(byte[] body, Activity? activity, BasicDeliverEventArgs ea, string? delegationGrant)
     {
         var processedSuccessfully = false;
         try
@@ -234,6 +245,10 @@ public sealed class RabbitMessageWorker : BackgroundService
             {
                 if (_channel?.IsOpen == true)
                     await _channel.BasicAckAsync(ea.DeliveryTag, multiple: false);
+
+                // Order is fixed: business op -> ACK -> DEL. A grant released before the ACK
+                // would leave a redelivery unable to mint a token.
+                await ReleaseDelegationGrantAsync(delegationGrant);
             }
             else
             {
@@ -258,13 +273,26 @@ public sealed class RabbitMessageWorker : BackgroundService
         }
     }
 
-    private static void ExtractHeaders(IReadOnlyBasicProperties properties, out string? tenantId, out string? traceId, out string? spanId, out string? securityContext, out string baggage)
+    /// <summary>
+    /// Removes the grant and its cached token after a successful settle. Best effort: if this
+    /// fails, the absolute TTL still bounds the grant.
+    /// </summary>
+    private async Task ReleaseDelegationGrantAsync(string? delegationGrant)
+    {
+        if (string.IsNullOrWhiteSpace(delegationGrant)) return;
+
+        _delegatedTokenProvider.Invalidate(delegationGrant);
+        await _delegationGrantStore.DeleteAsync(delegationGrant!);
+    }
+
+    private static void ExtractHeaders(IReadOnlyBasicProperties properties, out string? tenantId, out string? traceId, out string? spanId, out string? securityContext, out string baggage, out string? delegationGrant)
     {
         tenantId = GetHeader(properties, "TenantId");
         traceId = GetHeader(properties, "TraceId");
         spanId = GetHeader(properties, "SpanId");
         securityContext = GetHeader(properties, "SecurityContext");
         baggage = GetHeader(properties, "Baggage");
+        delegationGrant = GetHeader(properties, DelegationConstants.DelegationGrantHeader);
     }
 
     private static string? GetHeader(IReadOnlyBasicProperties properties, string key)

--- a/src/Genesis/setup_env.sh
+++ b/src/Genesis/setup_env.sh
@@ -53,6 +53,10 @@ set_env_variable "BlocksSecret__RootDatabaseName" "ROOT_DB"
 set_env_variable "BlocksSecret__EnableHsts" "true"
 set_env_variable "BlocksSecret__AllowedCorsOrigins" "https://app.example.com,https://admin.example.com"
 
+# Delegated access. One of BLOCKS_IAM_BASE_URL / BLOCKS_IAM_TOKEN_ENDPOINT is required, or the host
+# refuses to start. Must be IAM's internal address, never the public host.
+set_env_variable "BLOCKS_IAM_BASE_URL" "http://localhost:5000"
+
 echo "Environment variables have been set for the current session."
 
 if [[ "$OS_TYPE" == "Linux" || "$OS_TYPE" == "macOS" ]]; then

--- a/src/XUnitTest/Delegation/DelegatedAuthorizationHeadersTests.cs
+++ b/src/XUnitTest/Delegation/DelegatedAuthorizationHeadersTests.cs
@@ -1,0 +1,237 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using System.Text;
+
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// Delegation is opt-in per call. The caller asks for headers and passes them to
+/// <c>IHttpService</c>, so the call is still traced — but nothing is ever attached to a request the
+/// caller did not ask about. A worker calling a third party must not hand it a Blocks credential.
+/// </summary>
+public class DelegatedAuthorizationHeadersTests : IDisposable
+{
+    private const string TenantId = "tenant-1";
+    private const string TenantSalt = "salt-value";
+
+    private readonly bool _originalTestMode = BlocksContext.IsTestMode;
+
+    public DelegatedAuthorizationHeadersTests()
+    {
+        BlocksContext.IsTestMode = true;
+        BlocksContext.SetContext(BlocksContext.Create(
+            tenantId: TenantId, roles: null, userId: "user-1", isAuthenticated: true,
+            requestUri: null, organizationId: "org-1", expireOn: DateTime.UtcNow.AddHours(1),
+            email: null, permissions: null, userName: null, phoneNumber: null,
+            displayName: null, oauthToken: null, originalTenantId: TenantId));
+    }
+
+    public void Dispose()
+    {
+        BlocksContext.SetContext(null);
+        DelegatedTokenContext.Clear();
+        BlocksContext.IsTestMode = _originalTestMode;
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string? _token;
+
+        public StubHandler(string? token) => _token = token;
+
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+
+            if (_token is null)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent("{\"error\":\"invalid_grant\"}", Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    $"{{\"access_token\":\"{_token}\",\"token_type\":\"Bearer\",\"expires_in\":300}}",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+        }
+    }
+
+    private static (DelegatedTokenProvider Provider, StubHandler Handler) CreateProvider(string? token)
+    {
+        var handler = new StubHandler(token);
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory
+            .Setup(f => f.CreateClient(DelegationConstants.ExchangeHttpClientName))
+            .Returns(() => new HttpClient(handler, disposeHandler: false));
+
+        var tenants = new Mock<ITenants>();
+        tenants.Setup(t => t.GetTenantByID(TenantId)).Returns(new Blocks.Genesis.Tenant
+        {
+            TenantId = TenantId,
+            TenantSalt = TenantSalt,
+            DbConnectionString = "mongodb://unit-test",
+            JwtTokenParameters = new JwtTokenParameters
+            {
+                Issuer = "issuer",
+                Subject = "subject",
+                Audiences = [],
+                PublicCertificatePath = "none",
+                PublicCertificatePassword = string.Empty,
+                PrivateCertificatePassword = string.Empty,
+                IssueDate = DateTime.UtcNow
+            }
+        });
+
+        var resolver = new Mock<IDelegationTokenEndpointResolver>();
+        resolver
+            .Setup(r => r.GetTokenEndpointAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("http://blocks-iam:8080/api/oidc/token");
+
+        var provider = new DelegatedTokenProvider(
+            tenants.Object,
+            resolver.Object,
+            factory.Object,
+            new Mock<ILogger<DelegatedTokenProvider>>().Object);
+
+        return (provider, handler);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldReturnBearerAndTenantHeader_WhenAGrantIsInScope()
+    {
+        var (provider, _) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var headers = await provider.GetAuthorizationHeadersAsync();
+
+        Assert.Equal("Bearer delegated-token", headers[BlocksConstants.AuthorizationHeaderName]);
+        Assert.Equal(TenantId, headers[BlocksConstants.BlocksKey]);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldPreserveTheCallersOtherHeaders()
+    {
+        var (provider, _) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var headers = await provider.GetAuthorizationHeadersAsync(new Dictionary<string, string>
+        {
+            ["Accept"] = "application/json",
+            ["X-Correlation-Id"] = "abc"
+        });
+
+        Assert.Equal("application/json", headers["Accept"]);
+        Assert.Equal("abc", headers["X-Correlation-Id"]);
+        Assert.Equal("Bearer delegated-token", headers[BlocksConstants.AuthorizationHeaderName]);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldNotMutateTheCallersDictionary()
+    {
+        var (provider, _) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var callerHeaders = new Dictionary<string, string> { ["Accept"] = "application/json" };
+
+        await provider.GetAuthorizationHeadersAsync(callerHeaders);
+
+        // The caller may reuse this dictionary, so it must come back untouched.
+        Assert.Single(callerHeaders);
+        Assert.False(callerHeaders.ContainsKey(BlocksConstants.AuthorizationHeaderName));
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldReturnNothingExtra_WhenThereIsNoGrant()
+    {
+        var (provider, handler) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Clear();
+
+        var headers = await provider.GetAuthorizationHeadersAsync();
+
+        Assert.Empty(headers);
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldNeverOverrideACallerSuppliedAuthorization()
+    {
+        var (provider, handler) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var headers = await provider.GetAuthorizationHeadersAsync(new Dictionary<string, string>
+        {
+            ["Authorization"] = "Bearer caller-supplied"
+        });
+
+        Assert.Equal("Bearer caller-supplied", headers[BlocksConstants.AuthorizationHeaderName]);
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldTreatAuthorizationCaseInsensitively()
+    {
+        var (provider, handler) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var headers = await provider.GetAuthorizationHeadersAsync(new Dictionary<string, string>
+        {
+            ["authorization"] = "Bearer caller-supplied"
+        });
+
+        Assert.Equal("Bearer caller-supplied", headers[BlocksConstants.AuthorizationHeaderName]);
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldNotOverrideACallerSuppliedTenantHeader()
+    {
+        var (provider, _) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var headers = await provider.GetAuthorizationHeadersAsync(new Dictionary<string, string>
+        {
+            [BlocksConstants.BlocksKey] = "explicit-tenant"
+        });
+
+        Assert.Equal("explicit-tenant", headers[BlocksConstants.BlocksKey]);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldAddNothing_WhenTheGrantCannotBeRedeemed()
+    {
+        var (provider, _) = CreateProvider(token: null);
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        var headers = await provider.GetAuthorizationHeadersAsync(new Dictionary<string, string>
+        {
+            ["Accept"] = "application/json"
+        });
+
+        // The caller's headers survive; no half-formed credential is invented.
+        Assert.Single(headers);
+        Assert.Equal("application/json", headers["Accept"]);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationHeadersAsync_ShouldReuseTheCachedToken()
+    {
+        var (provider, handler) = CreateProvider("delegated-token");
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        await provider.GetAuthorizationHeadersAsync();
+        await provider.GetAuthorizationHeadersAsync();
+        await provider.GetAuthorizationHeadersAsync();
+
+        Assert.Equal(1, handler.Calls);
+    }
+}

--- a/src/XUnitTest/Delegation/DelegatedTokenProviderTests.cs
+++ b/src/XUnitTest/Delegation/DelegatedTokenProviderTests.cs
@@ -1,0 +1,375 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using System.Text;
+
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// Cache, single-flight and renewal behaviour of the exchange, plus the signature conformance
+/// vector shared with blocks-genesis-py.
+/// </summary>
+public class DelegatedTokenProviderTests : IDisposable
+{
+    private const string TenantId = "tenant-1";
+    private const string TenantSalt = "salt-value";
+    private const string Endpoint = "http://blocks-iam:8080/api/oidc/token";
+
+    private readonly bool _originalTestMode = BlocksContext.IsTestMode;
+
+    public DelegatedTokenProviderTests()
+    {
+        BlocksContext.IsTestMode = true;
+        BlocksContext.SetContext(BlocksContext.Create(
+            tenantId: TenantId, roles: null, userId: "user-1", isAuthenticated: true,
+            requestUri: null, organizationId: "org-1", expireOn: DateTime.UtcNow.AddHours(1),
+            email: null, permissions: null, userName: null, phoneNumber: null,
+            displayName: null, oauthToken: null, originalTenantId: TenantId));
+    }
+
+    public void Dispose()
+    {
+        BlocksContext.SetContext(null);
+        DelegatedTokenContext.Clear();
+        BlocksContext.IsTestMode = _originalTestMode;
+    }
+
+    /// <summary>Counts exchanges and lets a test choose the response per call.</summary>
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, int, HttpResponseMessage> _respond;
+        private int _calls;
+
+        public CountingHandler(Func<HttpRequestMessage, int, HttpResponseMessage> respond) => _respond = respond;
+
+        /// <summary>
+        /// Awaited before responding, so a test can hold the exchange open. Must be awaited rather
+        /// than blocked on: GetTokenAsync runs synchronously up to its first real await, so blocking
+        /// here would deadlock any caller not wrapped in Task.Run.
+        /// </summary>
+        public Func<Task>? Gate { get; set; }
+
+        public int Calls => Volatile.Read(ref _calls);
+        public List<Dictionary<string, string>> Forms { get; } = [];
+        public List<string?> BlocksKeyHeaders { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var index = Interlocked.Increment(ref _calls);
+
+            if (request.Content is not null)
+            {
+                var body = await request.Content.ReadAsStringAsync(cancellationToken);
+                var form = body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(pair => pair.Split('=', 2))
+                    .ToDictionary(parts => Uri.UnescapeDataString(parts[0]), parts => Uri.UnescapeDataString(parts[1].Replace('+', ' ')));
+
+                lock (Forms) Forms.Add(form);
+            }
+
+            lock (BlocksKeyHeaders)
+            {
+                BlocksKeyHeaders.Add(request.Headers.TryGetValues(BlocksConstants.BlocksKey, out var values) ? values.First() : null);
+            }
+
+            if (Gate is not null)
+            {
+                await Gate().ConfigureAwait(false);
+            }
+
+            return _respond(request, index);
+        }
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        public DateTimeOffset Now { get; set; } = new(2025, 2, 15, 0, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    private static HttpResponseMessage TokenResponse(string accessToken, int expiresIn = 300)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                $"{{\"access_token\":\"{accessToken}\",\"token_type\":\"Bearer\",\"expires_in\":{expiresIn}}}",
+                Encoding.UTF8,
+                "application/json")
+        };
+
+    private static (DelegatedTokenProvider Provider, CountingHandler Handler, FixedTimeProvider Clock) CreateProvider(
+        Func<HttpRequestMessage, int, HttpResponseMessage> respond,
+        string? tenantSalt = TenantSalt)
+    {
+        var handler = new CountingHandler(respond);
+        var clock = new FixedTimeProvider();
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory
+            .Setup(f => f.CreateClient(DelegationConstants.ExchangeHttpClientName))
+            .Returns(() => new HttpClient(handler, disposeHandler: false));
+
+        var tenants = new Mock<ITenants>();
+        tenants.Setup(t => t.GetTenantByID(TenantId)).Returns(
+            tenantSalt is null
+                ? null
+                : new Blocks.Genesis.Tenant
+                {
+                    TenantId = TenantId,
+                    TenantSalt = tenantSalt,
+                    DbConnectionString = "mongodb://unit-test",
+                    JwtTokenParameters = new JwtTokenParameters
+                    {
+                        Issuer = "issuer",
+                        Subject = "subject",
+                        Audiences = [],
+                        PublicCertificatePath = "none",
+                        PublicCertificatePassword = string.Empty,
+                        PrivateCertificatePassword = string.Empty,
+                        IssueDate = DateTime.UtcNow
+                    }
+                });
+
+        var resolver = new Mock<IDelegationTokenEndpointResolver>();
+        resolver.Setup(r => r.GetTokenEndpointAsync(TenantId, It.IsAny<CancellationToken>())).ReturnsAsync(Endpoint);
+
+        var provider = new DelegatedTokenProvider(
+            tenants.Object,
+            resolver.Object,
+            factory.Object,
+            new Mock<ILogger<DelegatedTokenProvider>>().Object,
+            activitySource: null,
+            timeProvider: clock);
+
+        return (provider, handler, clock);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldReturnNull_WhenNoGrantIsInScope()
+    {
+        var (provider, handler, _) = CreateProvider((_, _) => TokenResponse("t"));
+        DelegatedTokenContext.Clear();
+
+        Assert.Null(await provider.GetTokenAsync());
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldReturnNull_WhenContextCarriesNoTenant()
+    {
+        var (provider, handler, _) = CreateProvider((_, _) => TokenResponse("t"));
+        BlocksContext.SetContext(null);
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        Assert.Null(await provider.GetTokenAsync());
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldSendTheRfc8693FormAndTenantHeader()
+    {
+        var (provider, handler, clock) = CreateProvider((_, _) => TokenResponse("access-1"));
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        DelegatedTokenContext.Set(grantId);
+
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+
+        var form = handler.Forms.Single();
+        Assert.Equal(DelegationConstants.TokenExchangeGrantType, form["grant_type"]);
+        Assert.Equal(grantId, form["subject_token"]);
+        Assert.Equal(DelegationConstants.DelegationGrantTokenType, form["subject_token_type"]);
+        Assert.Equal(clock.Now.ToUnixTimeSeconds().ToString(), form["ts"]);
+        Assert.Equal(32, form["nonce"].Length);
+        Assert.Equal(64, form["sig"].Length);
+
+        // Signed with the tenant salt over the exact pipe-delimited input.
+        var expected = DelegationSignature.Compute(
+            TenantId, grantId, form["nonce"], clock.Now.ToUnixTimeSeconds(), TenantSalt);
+        Assert.Equal(expected, form["sig"]);
+
+        Assert.Equal(TenantId, handler.BlocksKeyHeaders.Single());
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldServeTheCachedToken_InsideValidity()
+    {
+        var (provider, handler, _) = CreateProvider((_, index) => TokenResponse($"access-{index}"));
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldRefetch_OnceInsideTheRenewalMargin()
+    {
+        // 300s lifetime, so the entry stops being served at 240s.
+        var (provider, handler, clock) = CreateProvider((_, index) => TokenResponse($"access-{index}", expiresIn: 300));
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+
+        clock.Now = clock.Now.AddSeconds(239);
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+        Assert.Equal(1, handler.Calls);
+
+        clock.Now = clock.Now.AddSeconds(2);
+        Assert.Equal("access-2", await provider.GetTokenAsync());
+        Assert.Equal(2, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldPerformExactlyOneExchange_ForFiftyConcurrentCallers()
+    {
+        var gate = new TaskCompletionSource();
+        var (provider, handler, _) = CreateProvider((_, index) => TokenResponse($"access-{index}"));
+        handler.Gate = () => gate.Task;
+
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        DelegatedTokenContext.Set(grantId);
+
+        var context = BlocksContext.GetContext();
+
+        // Each task re-establishes the ambient state: AsyncLocal does not flow into Task.Run in
+        // the way a fresh worker thread would, and the point of the test is one shared exchange.
+        var callers = Enumerable.Range(0, 50).Select(_ => Task.Run(async () =>
+        {
+            BlocksContext.SetContext(context);
+            DelegatedTokenContext.Set(grantId);
+            return await provider.GetTokenAsync();
+        })).ToArray();
+
+        gate.SetResult();
+        var tokens = await Task.WhenAll(callers);
+
+        Assert.Equal(1, handler.Calls);
+        Assert.All(tokens, token => Assert.Equal("access-1", token));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldReturnNull_AndNotCacheAFailure_WhenTheExchangeIsRejected()
+    {
+        var (provider, handler, _) = CreateProvider((_, index) => index == 1
+            ? new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":\"invalid_grant\"}", Encoding.UTF8, "application/json")
+            }
+            : TokenResponse("access-recovered"));
+
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        Assert.Null(await provider.GetTokenAsync());
+
+        // One rejection costs exactly one round trip: the call does not immediately retry.
+        Assert.Equal(1, handler.Calls);
+
+        // The rejection is not cached either, so a later call is free to try again.
+        Assert.Equal("access-recovered", await provider.GetTokenAsync());
+        Assert.Equal(2, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldReturnNull_WhenTheExchangeThrows()
+    {
+        var (provider, _, _) = CreateProvider((_, _) => throw new HttpRequestException("connection refused"));
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        Assert.Null(await provider.GetTokenAsync());
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldReturnNull_WhenTheTenantHasNoSalt()
+    {
+        var (provider, handler, _) = CreateProvider((_, _) => TokenResponse("t"), tenantSalt: null);
+        DelegatedTokenContext.Set(DelegationTestDoubles.SampleGrantId());
+
+        Assert.Null(await provider.GetTokenAsync());
+        Assert.Equal(0, handler.Calls);
+    }
+
+    [Fact]
+    public async Task Invalidate_ShouldDropTheCachedToken()
+    {
+        var (provider, handler, _) = CreateProvider((_, index) => TokenResponse($"access-{index}"));
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        DelegatedTokenContext.Set(grantId);
+
+        Assert.Equal("access-1", await provider.GetTokenAsync());
+
+        provider.Invalidate(grantId);
+
+        Assert.Equal("access-2", await provider.GetTokenAsync());
+        Assert.Equal(2, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ShouldNotCancelTheSharedExchange_WhenOneCallerGivesUp()
+    {
+        var released = new TaskCompletionSource();
+        var (provider, handler, _) = CreateProvider((_, index) => TokenResponse($"access-{index}"));
+        handler.Gate = () => released.Task;
+
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        DelegatedTokenContext.Set(grantId);
+
+        using var impatient = new CancellationTokenSource();
+        var abandoned = provider.GetTokenAsync(impatient.Token);
+
+        // A second caller joins the same in-flight exchange, then the first gives up.
+        var patient = Task.Run(async () =>
+        {
+            BlocksContext.SetContext(BlocksContext.Create(
+                tenantId: TenantId, roles: null, userId: "user-1", isAuthenticated: true,
+                requestUri: null, organizationId: "org-1", expireOn: DateTime.UtcNow.AddHours(1),
+                email: null, permissions: null, userName: null, phoneNumber: null,
+                displayName: null, oauthToken: null, originalTenantId: TenantId));
+            DelegatedTokenContext.Set(grantId);
+            return await provider.GetTokenAsync();
+        });
+
+        await impatient.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => abandoned);
+
+        released.SetResult();
+
+        // The exchange survived the cancellation and still served the caller that waited.
+        Assert.Equal("access-1", await patient);
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public void Sign_ShouldMatchTheCrossSdkConformanceVector()
+    {
+        var input = DelegationConstants.BuildSignatureInput(
+            DelegationConformanceVector.TenantId,
+            DelegationConformanceVector.DelegationId,
+            DelegationConformanceVector.Nonce,
+            DelegationConformanceVector.Ts);
+
+        Assert.Equal(DelegationConformanceVector.ExpectedSignatureInput, input);
+        Assert.Equal(
+            DelegationConformanceVector.ExpectedSignature,
+            DelegationSignature.Compute(input, DelegationConformanceVector.TenantSalt));
+        Assert.True(DelegationSignature.Verify(
+            DelegationConformanceVector.ExpectedSignature,
+            DelegationSignature.Compute(input, DelegationConformanceVector.TenantSalt)));
+        Assert.False(DelegationSignature.Verify(DelegationConformanceVector.ExpectedSignature, "deadbeef"));
+    }
+
+    [Fact]
+    public void NewNonce_ShouldBeThirtyTwoLowercaseHexChars()
+    {
+        var nonces = Enumerable.Range(0, 100).Select(_ => DelegationSignature.NewNonce()).ToList();
+
+        Assert.All(nonces, nonce =>
+        {
+            Assert.Equal(DelegationConstants.NonceRandomBytes * 2, nonce.Length);
+            Assert.Matches("^[0-9a-f]+$", nonce);
+        });
+
+        Assert.Equal(nonces.Count, nonces.Distinct(StringComparer.Ordinal).Count());
+    }
+}

--- a/src/XUnitTest/Delegation/DelegationConformanceVector.cs
+++ b/src/XUnitTest/Delegation/DelegationConformanceVector.cs
@@ -1,0 +1,23 @@
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// The cross-SDK signature conformance vector. blocks-genesis-py asserts the same five inputs and
+/// the same expected signature, so a divergence in either SDK fails a test rather than a
+/// production exchange.
+/// <para>
+/// Keep in sync with <c>tests/test_delegation_conformance.py</c> in blocks-genesis-py.
+/// </para>
+/// </summary>
+internal static class DelegationConformanceVector
+{
+    public const string TenantId = "tenant-abc";
+    public const string DelegationId = "dg_00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    public const string Nonce = "0f1e2d3c4b5a69788796a5b4c3d2e1f0";
+    public const long Ts = 1739577600L;
+    public const string TenantSalt = "d3f1c0de-5a17-4b0c-9e8a-1f2b3c4d5e6f";
+
+    public const string ExpectedSignatureInput =
+        "tenant-abc|dg_00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff|0f1e2d3c4b5a69788796a5b4c3d2e1f0|1739577600";
+
+    public const string ExpectedSignature = "c01a5f122b9793b09385796b95f00ec3ebb28528d1043dc96cf3a9fe7628d560";
+}

--- a/src/XUnitTest/Delegation/DelegationGrantFactoryTests.cs
+++ b/src/XUnitTest/Delegation/DelegationGrantFactoryTests.cs
@@ -1,0 +1,181 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// Send-side rules: no authenticated user means no grant, and a worker-originated send carries the
+/// version material forward from the grant it already holds.
+/// </summary>
+public class DelegationGrantFactoryTests : IDisposable
+{
+    private readonly bool _originalTestMode = BlocksContext.IsTestMode;
+
+    public DelegationGrantFactoryTests()
+    {
+        BlocksContext.IsTestMode = true;
+    }
+
+    public void Dispose()
+    {
+        BlocksContext.SetContext(null);
+        DelegatedTokenContext.Clear();
+        BlocksContext.IsTestMode = _originalTestMode;
+    }
+
+    private static (DelegationGrantFactory Factory, Mock<IDelegationGrantStore> Store) CreateFactory()
+    {
+        var store = new Mock<IDelegationGrantStore>();
+        var factory = new DelegationGrantFactory(store.Object, new Mock<ILogger<DelegationGrantFactory>>().Object);
+        return (factory, store);
+    }
+
+    private static BlocksContext Context(bool authenticated, string userId = "user-1", string tenantId = "tenant-1")
+        => BlocksContext.Create(
+            tenantId: tenantId, roles: ["admin"], userId: userId, isAuthenticated: authenticated,
+            requestUri: "https://unit.test", organizationId: "org-1", expireOn: DateTime.UtcNow.AddHours(1),
+            email: null, permissions: null, userName: null, phoneNumber: null, displayName: null,
+            oauthToken: null, originalTenantId: tenantId);
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldReturnNull_WhenThereIsNoContext()
+    {
+        var (factory, store) = CreateFactory();
+        BlocksContext.SetContext(null);
+
+        Assert.Null(await factory.CreateForSendAsync());
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldReturnNull_WhenTheUserIsNotAuthenticated()
+    {
+        var (factory, store) = CreateFactory();
+        BlocksContext.SetContext(Context(authenticated: false));
+
+        Assert.Null(await factory.CreateForSendAsync());
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldReturnNull_WhenContextHasNoUserId()
+    {
+        var (factory, store) = CreateFactory();
+        BlocksContext.SetContext(Context(authenticated: true, userId: string.Empty));
+
+        Assert.Null(await factory.CreateForSendAsync());
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldReturnNull_WhenNoVersionMaterialIsAvailable()
+    {
+        // Authenticated context, but no HttpContext claims and no held grant: nothing to put in the record.
+        var (factory, store) = CreateFactory();
+        BlocksContext.SetContext(Context(authenticated: true));
+        DelegatedTokenContext.Clear();
+
+        Assert.Null(await factory.CreateForSendAsync());
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldChainFromTheHeldGrant_ForWorkerOriginatedSends()
+    {
+        var (factory, store) = CreateFactory();
+        var heldGrant = DelegationTestDoubles.SampleGrantId('b');
+        var newGrant = DelegationTestDoubles.SampleGrantId('c');
+
+        store.Setup(s => s.GetAsync(heldGrant)).ReturnsAsync(new DelegationGrantRecord
+        {
+            TenantId = "tenant-1", UserId = "user-1", OrganizationId = "org-1", TokenVersion = "4", SecurityStamp = "stamp-4"
+        });
+        store
+            .Setup(s => s.CreateAsync(It.IsAny<BlocksContext>(), "4", "stamp-4", It.IsAny<TimeSpan?>()))
+            .ReturnsAsync(newGrant);
+
+        BlocksContext.SetContext(Context(authenticated: true));
+        DelegatedTokenContext.Set(heldGrant);
+
+        Assert.Equal(newGrant, await factory.CreateForSendAsync());
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), "4", "stamp-4", It.IsAny<TimeSpan?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldForwardTheTtlOverride()
+    {
+        var (factory, store) = CreateFactory();
+        var heldGrant = DelegationTestDoubles.SampleGrantId('d');
+
+        store.Setup(s => s.GetAsync(heldGrant)).ReturnsAsync(new DelegationGrantRecord
+        {
+            TenantId = "tenant-1", UserId = "user-1", TokenVersion = "1", SecurityStamp = "s"
+        });
+        store
+            .Setup(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromHours(9)))
+            .ReturnsAsync(DelegationTestDoubles.SampleGrantId('e'));
+
+        BlocksContext.SetContext(Context(authenticated: true));
+        DelegatedTokenContext.Set(heldGrant);
+
+        await factory.CreateForSendAsync(TimeSpan.FromHours(9));
+
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromHours(9)), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldNotChain_WhenTheHeldGrantBelongsToAnotherTenant()
+    {
+        var (factory, store) = CreateFactory();
+        var heldGrant = DelegationTestDoubles.SampleGrantId('f');
+
+        store.Setup(s => s.GetAsync(heldGrant)).ReturnsAsync(new DelegationGrantRecord
+        {
+            TenantId = "other-tenant", UserId = "user-1", TokenVersion = "1", SecurityStamp = "s"
+        });
+
+        BlocksContext.SetContext(Context(authenticated: true, tenantId: "tenant-1"));
+        DelegatedTokenContext.Set(heldGrant);
+
+        Assert.Null(await factory.CreateForSendAsync());
+        store.Verify(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateForSendAsync_ShouldReturnNull_WhenTheStoreThrows()
+    {
+        // A send must not fail because delegation could not be set up.
+        var (factory, store) = CreateFactory();
+        var heldGrant = DelegationTestDoubles.SampleGrantId('a');
+
+        store.Setup(s => s.GetAsync(heldGrant)).ReturnsAsync(new DelegationGrantRecord
+        {
+            TenantId = "tenant-1", UserId = "user-1", TokenVersion = "1", SecurityStamp = "s"
+        });
+        store
+            .Setup(s => s.CreateAsync(It.IsAny<BlocksContext>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan?>()))
+            .ThrowsAsync(new TimeoutException("redis down"));
+
+        BlocksContext.SetContext(Context(authenticated: true));
+        DelegatedTokenContext.Set(heldGrant);
+
+        Assert.Null(await factory.CreateForSendAsync());
+    }
+
+    [Fact]
+    public void DelegatedTokenContext_ShouldRejectMalformedIds()
+    {
+        DelegatedTokenContext.Set("dg_short");
+        Assert.False(DelegatedTokenContext.HasGrant);
+        Assert.Null(DelegatedTokenContext.Current);
+
+        var valid = DelegationTestDoubles.SampleGrantId();
+        DelegatedTokenContext.Set(valid);
+        Assert.True(DelegatedTokenContext.HasGrant);
+        Assert.Equal(valid, DelegatedTokenContext.Current);
+
+        DelegatedTokenContext.Clear();
+        Assert.False(DelegatedTokenContext.HasGrant);
+    }
+}

--- a/src/XUnitTest/Delegation/DelegationGrantStoreTests.cs
+++ b/src/XUnitTest/Delegation/DelegationGrantStoreTests.cs
@@ -1,0 +1,229 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StackExchange.Redis;
+using System.Text.Json;
+
+namespace XUnitTest.Delegation;
+
+public class DelegationGrantStoreTests
+{
+    private static BlocksContext AuthenticatedContext(string tenantId = "tenant-1", string userId = "user-1", string orgId = "org-1")
+        => BlocksContext.Create(
+            tenantId: tenantId,
+            roles: ["admin"],
+            userId: userId,
+            isAuthenticated: true,
+            requestUri: "https://unit.test",
+            organizationId: orgId,
+            expireOn: DateTime.UtcNow.AddHours(1),
+            email: "user@unit.test",
+            permissions: ["p1"],
+            userName: "user",
+            phoneNumber: "+10000000000",
+            displayName: "User",
+            oauthToken: "token",
+            originalTenantId: tenantId);
+
+    private static (DelegationGrantStore Store, Mock<IDatabase> Database, Mock<ICacheClient> Cache) CreateStore()
+    {
+        var database = new Mock<IDatabase>();
+        var cache = new Mock<ICacheClient>();
+        cache.Setup(c => c.CacheDatabase()).Returns(database.Object);
+
+        var store = new DelegationGrantStore(cache.Object, new Mock<ILogger<DelegationGrantStore>>().Object);
+        return (store, database, cache);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldWriteRecordWithTwoDayTtl_WhenNoOverrideGiven()
+    {
+        var (store, database, _) = CreateStore();
+
+        RedisKey capturedKey = default;
+        RedisValue capturedValue = default;
+        TimeSpan? capturedExpiry = null;
+
+        database
+            .Setup(db => db.StringSetAsync(
+                It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(), It.IsAny<When>(), It.IsAny<CommandFlags>()))
+            .Callback((RedisKey key, RedisValue value, TimeSpan? expiry, bool _, When __, CommandFlags ___) =>
+            {
+                capturedKey = key;
+                capturedValue = value;
+                capturedExpiry = expiry;
+            })
+            .ReturnsAsync(true);
+
+        var id = await store.CreateAsync(AuthenticatedContext(), tokenVersion: "3", securityStamp: "stamp-9");
+
+        Assert.Equal(DelegationConstants.GrantKeyPrefix + id, capturedKey.ToString());
+        Assert.Equal(DelegationConstants.DefaultGrantTtl, capturedExpiry);
+
+        var record = JsonSerializer.Deserialize<DelegationGrantRecord>(capturedValue.ToString());
+        Assert.NotNull(record);
+        Assert.Equal("tenant-1", record!.TenantId);
+        Assert.Equal("user-1", record.UserId);
+        Assert.Equal("org-1", record.OrganizationId);
+        Assert.Equal("3", record.TokenVersion);
+        Assert.Equal("stamp-9", record.SecurityStamp);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldHonourTtlOverride()
+    {
+        var (store, database, _) = CreateStore();
+        TimeSpan? capturedExpiry = null;
+
+        database
+            .Setup(db => db.StringSetAsync(
+                It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(), It.IsAny<When>(), It.IsAny<CommandFlags>()))
+            .Callback((RedisKey _, RedisValue __, TimeSpan? expiry, bool ___, When ____, CommandFlags _____) => capturedExpiry = expiry)
+            .ReturnsAsync(true);
+
+        await store.CreateAsync(AuthenticatedContext(), "1", "stamp", TimeSpan.FromHours(6));
+
+        Assert.Equal(TimeSpan.FromHours(6), capturedExpiry);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldFallBackToDefaultTtl_WhenOverrideIsNotPositive()
+    {
+        var (store, database, _) = CreateStore();
+        TimeSpan? capturedExpiry = null;
+
+        database
+            .Setup(db => db.StringSetAsync(
+                It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<bool>(), It.IsAny<When>(), It.IsAny<CommandFlags>()))
+            .Callback((RedisKey _, RedisValue __, TimeSpan? expiry, bool ___, When ____, CommandFlags _____) => capturedExpiry = expiry)
+            .ReturnsAsync(true);
+
+        await store.CreateAsync(AuthenticatedContext(), "1", "stamp", TimeSpan.Zero);
+
+        Assert.Equal(DelegationConstants.DefaultGrantTtl, capturedExpiry);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldReject_WhenContextHasNoAuthenticatedUser()
+    {
+        var (store, _, _) = CreateStore();
+
+        var contextWithoutUser = BlocksContext.Create(
+            tenantId: "tenant-1", roles: null, userId: null, isAuthenticated: false,
+            requestUri: null, organizationId: null, expireOn: DateTime.UtcNow,
+            email: null, permissions: null, userName: null, phoneNumber: null,
+            displayName: null, oauthToken: null, originalTenantId: null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => store.CreateAsync(contextWithoutUser, "1", "stamp"));
+    }
+
+    [Fact]
+    public void NewGrantId_ShouldBePrefixedHex_AndUnique()
+    {
+        var ids = Enumerable.Range(0, 200).Select(_ => DelegationGrantStore.NewGrantId()).ToList();
+
+        Assert.All(ids, id =>
+        {
+            Assert.StartsWith(DelegationConstants.GrantIdPrefix, id, StringComparison.Ordinal);
+            Assert.Equal(DelegationConstants.GrantIdPrefix.Length + 64, id.Length);
+            Assert.True(DelegationGrantStore.IsWellFormed(id));
+        });
+
+        Assert.Equal(ids.Count, ids.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("dg_", false)]
+    [InlineData("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff", false)]
+    [InlineData("dg_00112233445566778899AABBCCDDEEFF00112233445566778899aabbccddeeff", false)]
+    [InlineData("dg_00112233445566778899aabbccddeeff00112233445566778899aabbccddeef", false)]
+    [InlineData("dg_00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff", true)]
+    public void IsWellFormed_ShouldAcceptOnlyLowercaseHexOfExactLength(string? candidate, bool expected)
+    {
+        Assert.Equal(expected, DelegationGrantStore.IsWellFormed(candidate));
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldReturnNull_ForMalformedIdWithoutTouchingRedis()
+    {
+        var (store, _, cache) = CreateStore();
+
+        Assert.Null(await store.GetAsync("not-a-grant"));
+
+        cache.Verify(c => c.GetStringValueAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldReturnNull_WhenStoredJsonIsUnreadable()
+    {
+        var (store, _, cache) = CreateStore();
+        var id = DelegationTestDoubles.SampleGrantId();
+
+        cache.Setup(c => c.GetStringValueAsync(DelegationConstants.GrantKeyPrefix + id)).ReturnsAsync("{not-json");
+
+        Assert.Null(await store.GetAsync(id));
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldRoundTripTheRecord()
+    {
+        var (store, _, cache) = CreateStore();
+        var id = DelegationTestDoubles.SampleGrantId();
+
+        var stored = JsonSerializer.Serialize(new DelegationGrantRecord
+        {
+            TenantId = "t", UserId = "u", OrganizationId = "o", TokenVersion = "7", SecurityStamp = "s"
+        });
+        cache.Setup(c => c.GetStringValueAsync(DelegationConstants.GrantKeyPrefix + id)).ReturnsAsync(stored);
+
+        var record = await store.GetAsync(id);
+
+        Assert.NotNull(record);
+        Assert.Equal("u", record!.UserId);
+        Assert.Equal("7", record.TokenVersion);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldRemoveTheGrantKey()
+    {
+        var (store, _, cache) = CreateStore();
+        var id = DelegationTestDoubles.SampleGrantId();
+        cache.Setup(c => c.RemoveKeyAsync(It.IsAny<string>())).ReturnsAsync(true);
+
+        await store.DeleteAsync(id);
+
+        cache.Verify(c => c.RemoveKeyAsync(DelegationConstants.GrantKeyPrefix + id), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ShouldSwallowRedisFailures_SoTheTtlRemainsTheBackstop()
+    {
+        var (store, _, cache) = CreateStore();
+        cache.Setup(c => c.RemoveKeyAsync(It.IsAny<string>())).ThrowsAsync(new TimeoutException("redis down"));
+
+        var exception = await Record.ExceptionAsync(() => store.DeleteAsync(DelegationTestDoubles.SampleGrantId()));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void RecordSerialization_ShouldUsePascalCaseFieldNames()
+    {
+        var json = JsonSerializer.Serialize(new DelegationGrantRecord
+        {
+            TenantId = "t", UserId = "u", OrganizationId = "o", TokenVersion = "1", SecurityStamp = "s"
+        });
+
+        // The Python SDK and IAM read these exact names.
+        Assert.Contains("\"TenantId\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"UserId\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"OrganizationId\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"TokenVersion\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"SecurityStamp\"", json, StringComparison.Ordinal);
+    }
+}

--- a/src/XUnitTest/Delegation/DelegationMessageFlowTests.cs
+++ b/src/XUnitTest/Delegation/DelegationMessageFlowTests.cs
@@ -1,0 +1,459 @@
+using Azure.Messaging.ServiceBus;
+using Blocks.Genesis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// End-to-end wiring on both transports: the send stamps the header, the worker reads it into
+/// <see cref="DelegatedTokenContext"/>, and the grant is released only after a successful settle.
+/// </summary>
+public class DelegationMessageFlowTests : IDisposable
+{
+    private const string AzureConnection =
+        "Endpoint=sb://unit-test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=01234567890123456789012345678901234567890123456789=";
+
+    private readonly bool _originalTestMode = BlocksContext.IsTestMode;
+
+    public void Dispose()
+    {
+        BlocksContext.SetContext(null);
+        DelegatedTokenContext.Clear();
+        BlocksContext.IsTestMode = _originalTestMode;
+    }
+
+    private sealed record Payload
+    {
+        public string Value { get; init; } = string.Empty;
+    }
+
+    // ---------------------------------------------------------------- Azure send
+
+    [Fact]
+    public async Task AzureSend_ShouldStampTheDelegationGrantHeader_WhenAGrantIsCreated()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var factory = DelegationTestDoubles.GrantFactory(grantId);
+
+        var captured = await CaptureAzureSend(factory.Object, new ConsumerMessage<Payload>
+        {
+            ConsumerName = "orders-queue",
+            Payload = new Payload { Value = "v" }
+        });
+
+        Assert.True(captured.ApplicationProperties.TryGetValue(DelegationConstants.DelegationGrantHeader, out var header));
+        Assert.Equal(grantId, header);
+
+        // SecurityContext is still sent: it remains the context and tracing channel.
+        Assert.True(captured.ApplicationProperties.ContainsKey("SecurityContext"));
+    }
+
+    [Fact]
+    public async Task AzureSend_ShouldOmitTheHeader_WhenThereIsNoGrant()
+    {
+        var captured = await CaptureAzureSend(DelegationTestDoubles.NoGrantFactory(), new ConsumerMessage<Payload>
+        {
+            ConsumerName = "orders-queue",
+            Payload = new Payload { Value = "v" }
+        });
+
+        Assert.False(captured.ApplicationProperties.ContainsKey(DelegationConstants.DelegationGrantHeader));
+    }
+
+    [Fact]
+    public async Task AzureSend_ShouldPassTheTtlOverrideToTheFactory()
+    {
+        var factory = DelegationTestDoubles.GrantFactory(DelegationTestDoubles.SampleGrantId());
+
+        await CaptureAzureSend(factory.Object, new ConsumerMessage<Payload>
+        {
+            ConsumerName = "orders-queue",
+            Payload = new Payload { Value = "v" },
+            DelegationTtl = TimeSpan.FromHours(5)
+        });
+
+        factory.Verify(f => f.CreateForSendAsync(TimeSpan.FromHours(5)), Times.Once);
+    }
+
+    private static async Task<ServiceBusMessage> CaptureAzureSend(IDelegationGrantFactory grantFactory, ConsumerMessage<Payload> message)
+    {
+        var sender = new Mock<ServiceBusSender>();
+        ServiceBusMessage? captured = null;
+
+        sender
+            .Setup(s => s.SendMessageAsync(It.IsAny<ServiceBusMessage>(), It.IsAny<CancellationToken>()))
+            .Callback((ServiceBusMessage sent, CancellationToken _) => captured = sent)
+            .Returns(Task.CompletedTask);
+
+        var client = new AzureMessageClient(
+            new MessageConfiguration
+            {
+                Connection = AzureConnection,
+                AzureServiceBusConfiguration = new AzureServiceBusConfiguration { Queues = [], Topics = [] }
+            },
+            new ActivitySource("delegation-azure-send-" + Guid.NewGuid().ToString("N")),
+            grantFactory);
+
+        var senders = (ConcurrentDictionary<string, ServiceBusSender>)typeof(AzureMessageClient)
+            .GetField("_senders", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(client)!;
+        senders[message.ConsumerName] = sender.Object;
+
+        await client.SendToConsumerAsync(message);
+
+        Assert.NotNull(captured);
+        return captured!;
+    }
+
+    // ---------------------------------------------------------------- Azure worker
+
+    [Fact]
+    public async Task AzureWorker_ShouldReleaseTheGrant_AfterASuccessfulSettle()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var store = new Mock<IDelegationGrantStore>();
+        var provider = new Mock<IDelegatedTokenProvider>();
+
+        var argsMock = await RunAzureWorker(grantId, store.Object, provider.Object, envelopeBody: "{\"Type\":\"NoRoute\",\"Body\":\"{}\"}");
+
+        argsMock.Verify(a => a.CompleteMessageAsync(It.IsAny<ServiceBusReceivedMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.DeleteAsync(grantId), Times.Once);
+        provider.Verify(p => p.Invalidate(grantId), Times.Once);
+    }
+
+    [Fact]
+    public async Task AzureWorker_ShouldRetainTheGrant_WhenProcessingFails()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var store = new Mock<IDelegationGrantStore>();
+        var provider = new Mock<IDelegatedTokenProvider>();
+
+        // A malformed envelope makes the dispatch throw, so the message is dead-lettered rather
+        // than completed. The grant must survive so a redelivery can still mint a token.
+        var argsMock = await RunAzureWorker(grantId, store.Object, provider.Object, envelopeBody: "not-json-at-all");
+
+        argsMock.Verify(a => a.CompleteMessageAsync(It.IsAny<ServiceBusReceivedMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+        store.Verify(s => s.DeleteAsync(It.IsAny<string>()), Times.Never);
+        provider.Verify(p => p.Invalidate(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AzureWorker_ShouldNotCallTheStore_WhenTheMessageHasNoGrant()
+    {
+        var store = new Mock<IDelegationGrantStore>();
+        var provider = new Mock<IDelegatedTokenProvider>();
+
+        await RunAzureWorker(null, store.Object, provider.Object, envelopeBody: "{\"Type\":\"NoRoute\",\"Body\":\"{}\"}");
+
+        store.Verify(s => s.DeleteAsync(It.IsAny<string>()), Times.Never);
+        provider.Verify(p => p.Invalidate(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AzureWorker_ShouldExposeTheGrantToTheHandler()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var observed = new List<string?>();
+
+        await RunAzureWorker(
+            grantId,
+            new Mock<IDelegationGrantStore>().Object,
+            new Mock<IDelegatedTokenProvider>().Object,
+            envelopeBody: "{\"Type\":\"" + nameof(Payload) + "\",\"Body\":\"{}\"}",
+            observeGrant: observed);
+
+        Assert.Equal(grantId, Assert.Single(observed));
+    }
+
+    private static async Task<Mock<Azure.Messaging.ServiceBus.ProcessMessageEventArgs>> RunAzureWorker(
+        string? grantId,
+        IDelegationGrantStore store,
+        IDelegatedTokenProvider provider,
+        string envelopeBody,
+        List<string?>? observeGrant = null)
+    {
+        var originalTestMode = BlocksContext.IsTestMode;
+        try
+        {
+            BlocksContext.IsTestMode = true;
+            BlocksContext.ClearContext();
+
+            var properties = new Dictionary<string, object>
+            {
+                ["TraceId"] = "0123456789abcdef0123456789abcdef",
+                ["SpanId"] = "0123456789abcdef",
+                ["TenantId"] = "tenant-1",
+                ["SecurityContext"] = "{}",
+                ["Baggage"] = "{}"
+            };
+
+            if (grantId is not null)
+            {
+                properties[DelegationConstants.DelegationGrantHeader] = grantId;
+            }
+
+            var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: BinaryData.FromString(envelopeBody),
+                messageId: "delegation-" + Guid.NewGuid().ToString("N"),
+                properties: properties);
+
+            var receiver = new Mock<ServiceBusReceiver>();
+            var argsMock = new Mock<Azure.Messaging.ServiceBus.ProcessMessageEventArgs>(message, receiver.Object, CancellationToken.None);
+
+            var worker = new AzureMessageWorker(
+                new Mock<ILogger<AzureMessageWorker>>().Object,
+                new MessageConfiguration
+                {
+                    Connection = AzureConnection,
+                    AzureServiceBusConfiguration = new AzureServiceBusConfiguration { Queues = [], Topics = [] }
+                },
+                CreateConsumer(observeGrant),
+                new ActivitySource("delegation-azure-worker-" + Guid.NewGuid().ToString("N")),
+                store,
+                provider);
+
+            var handler = typeof(AzureMessageWorker).GetMethod("MessageHandler", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            await (Task)handler.Invoke(worker, [argsMock.Object])!;
+
+            return argsMock;
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+            BlocksContext.IsTestMode = originalTestMode;
+        }
+    }
+
+    // ---------------------------------------------------------------- Rabbit send
+
+    [Fact]
+    public async Task RabbitSend_ShouldStampTheDelegationGrantHeader_WhenAGrantIsCreated()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var headers = await CaptureRabbitSend(DelegationTestDoubles.GrantFactory(grantId).Object);
+
+        Assert.True(headers.TryGetValue(DelegationConstants.DelegationGrantHeader, out var header));
+        Assert.Equal(grantId, header);
+        Assert.True(headers.ContainsKey("SecurityContext"));
+    }
+
+    [Fact]
+    public async Task RabbitSend_ShouldOmitTheHeader_WhenThereIsNoGrant()
+    {
+        var headers = await CaptureRabbitSend(DelegationTestDoubles.NoGrantFactory());
+
+        Assert.False(headers.ContainsKey(DelegationConstants.DelegationGrantHeader));
+    }
+
+    private static async Task<IDictionary<string, object?>> CaptureRabbitSend(IDelegationGrantFactory grantFactory)
+    {
+        var channel = new Mock<IChannel>();
+        channel.SetupGet(c => c.IsOpen).Returns(true);
+
+        IDictionary<string, object?>? captured = null;
+        channel
+            .Setup(c => c.BasicPublishAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(),
+                It.IsAny<BasicProperties>(), It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string __, bool ___, BasicProperties properties, ReadOnlyMemory<byte> ____, CancellationToken _____) =>
+                captured = properties.Headers)
+            .Returns(ValueTask.CompletedTask);
+
+        var rabbitService = new Mock<IRabbitMqService>();
+        rabbitService.Setup(s => s.CreateConnectionAsync()).Returns(Task.CompletedTask);
+        rabbitService.SetupGet(s => s.RabbitMqChannel).Returns(channel.Object);
+
+        var client = new RabbitMessageClient(
+            new Mock<ILogger<RabbitMessageClient>>().Object,
+            rabbitService.Object,
+            new MessageConfiguration { RabbitMqConfiguration = new RabbitMqConfiguration() },
+            new ActivitySource("delegation-rabbit-send-" + Guid.NewGuid().ToString("N")),
+            grantFactory);
+
+        await client.SendToConsumerAsync(new ConsumerMessage<Payload>
+        {
+            ConsumerName = "orders.queue",
+            Payload = new Payload { Value = "v" }
+        });
+
+        Assert.NotNull(captured);
+        return captured!;
+    }
+
+    // ---------------------------------------------------------------- Rabbit worker
+
+    [Fact]
+    public async Task RabbitWorker_ShouldReleaseTheGrant_AfterASuccessfulAck()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var store = new Mock<IDelegationGrantStore>();
+        var provider = new Mock<IDelegatedTokenProvider>();
+
+        var channel = await RunRabbitWorker(grantId, store.Object, provider.Object, body: "{\"Type\":\"NoRoute\",\"Body\":\"{}\"}");
+
+        channel.Verify(c => c.BasicAckAsync(It.IsAny<ulong>(), false, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.DeleteAsync(grantId), Times.Once);
+        provider.Verify(p => p.Invalidate(grantId), Times.Once);
+    }
+
+    [Fact]
+    public async Task RabbitWorker_ShouldExposeTheGrantToTheHandler()
+    {
+        var grantId = DelegationTestDoubles.SampleGrantId();
+        var observed = new List<string?>();
+
+        await RunRabbitWorker(
+            grantId,
+            new Mock<IDelegationGrantStore>().Object,
+            new Mock<IDelegatedTokenProvider>().Object,
+            body: "{\"Type\":\"" + nameof(Payload) + "\",\"Body\":\"{}\"}",
+            observeGrant: observed);
+
+        Assert.Equal(grantId, Assert.Single(observed));
+    }
+
+    [Fact]
+    public async Task RabbitWorker_ShouldNotCallTheStore_WhenTheMessageHasNoGrant()
+    {
+        var store = new Mock<IDelegationGrantStore>();
+        var provider = new Mock<IDelegatedTokenProvider>();
+
+        await RunRabbitWorker(null, store.Object, provider.Object, body: "{\"Type\":\"NoRoute\",\"Body\":\"{}\"}");
+
+        store.Verify(s => s.DeleteAsync(It.IsAny<string>()), Times.Never);
+        provider.Verify(p => p.Invalidate(It.IsAny<string>()), Times.Never);
+    }
+
+    private static async Task<Mock<IChannel>> RunRabbitWorker(
+        string? grantId,
+        IDelegationGrantStore store,
+        IDelegatedTokenProvider provider,
+        string body,
+        List<string?>? observeGrant = null)
+    {
+        const string queueName = "orders.queue";
+
+        var channel = new Mock<IChannel>();
+        channel.SetupGet(c => c.IsOpen).Returns(true);
+        channel
+            .Setup(c => c.BasicAckAsync(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+        channel
+            .Setup(c => c.BasicNackAsync(It.IsAny<ulong>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var worker = new RabbitMessageWorker(
+            new Mock<ILogger<RabbitMessageWorker>>().Object,
+            new MessageConfiguration
+            {
+                RabbitMqConfiguration = new RabbitMqConfiguration
+                {
+                    ConsumerSubscriptions = [ConsumerSubscription.BindToQueue(queueName, 3)]
+                }
+            },
+            new Mock<IRabbitMqService>().Object,
+            CreateConsumer(observeGrant),
+            new ActivitySource("delegation-rabbit-worker-" + Guid.NewGuid().ToString("N")),
+            store,
+            provider);
+
+        typeof(RabbitMessageWorker)
+            .GetField("_channel", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(worker, channel.Object);
+
+        var eventArgs = CreateDeliverArgs(queueName, body, grantId);
+
+        var handler = typeof(RabbitMessageWorker).GetMethod("ProcessMessageInternalAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        await (Task)handler.Invoke(worker, [eventArgs])!;
+
+        return channel;
+    }
+
+    private static BasicDeliverEventArgs CreateDeliverArgs(string routingKey, string body, string? grantId)
+    {
+        var eventArgs = (BasicDeliverEventArgs)RuntimeHelpers.GetUninitializedObject(typeof(BasicDeliverEventArgs));
+
+        var headers = new Dictionary<string, object?>
+        {
+            ["TenantId"] = Encoding.UTF8.GetBytes("tenant-1"),
+            ["TraceId"] = Encoding.UTF8.GetBytes("0123456789abcdef0123456789abcdef"),
+            ["SpanId"] = Encoding.UTF8.GetBytes("0123456789abcdef"),
+            ["SecurityContext"] = Encoding.UTF8.GetBytes("{}"),
+            ["Baggage"] = Encoding.UTF8.GetBytes("{}")
+        };
+
+        if (grantId is not null)
+        {
+            headers[DelegationConstants.DelegationGrantHeader] = Encoding.UTF8.GetBytes(grantId);
+        }
+
+        SetMember(eventArgs, "RoutingKey", routingKey);
+        SetMember(eventArgs, "DeliveryTag", 1UL);
+        SetMember(eventArgs, "BasicProperties", new BasicProperties { Headers = headers });
+        SetMember(eventArgs, "Body", new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(body)));
+
+        return eventArgs;
+    }
+
+    private static void SetMember(object target, string name, object value)
+    {
+        var type = target.GetType();
+
+        var property = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property?.SetMethod is not null)
+        {
+            property.SetValue(target, value);
+            return;
+        }
+
+        var field = type.GetField($"<{name}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
+    }
+
+    // ---------------------------------------------------------------- consumer probe
+
+    /// <summary>
+    /// A consumer that records what <see cref="DelegatedTokenContext"/> holds while the handler runs.
+    /// This is the whole point of the header: handler code sees a grant without doing anything.
+    /// </summary>
+    private sealed class GrantObservingConsumer : IConsumer<Payload>
+    {
+        private readonly List<string?> _observed;
+
+        public GrantObservingConsumer(List<string?> observed) => _observed = observed;
+
+        public Task Consume(Payload message)
+        {
+            lock (_observed) _observed.Add(DelegatedTokenContext.Current);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static Consumer CreateConsumer(List<string?>? observeGrant)
+    {
+        var services = new ServiceCollection();
+
+        if (observeGrant is not null)
+        {
+            // Registered by implementation type: RoutingTable skips factory registrations, so a
+            // closure-based probe would never be routed to.
+            services.AddSingleton(observeGrant);
+            services.AddSingleton<IConsumer<Payload>, GrantObservingConsumer>();
+        }
+
+        var routing = new RoutingTable(services);
+        return new Consumer(new Mock<ILogger<Consumer>>().Object, services.BuildServiceProvider(), routing);
+    }
+}

--- a/src/XUnitTest/Delegation/DelegationTestDoubles.cs
+++ b/src/XUnitTest/Delegation/DelegationTestDoubles.cs
@@ -1,0 +1,35 @@
+using Blocks.Genesis;
+using Moq;
+
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// Shared delegation doubles. Most message-client and worker tests predate delegated access and
+/// only need the dependency satisfied, so the defaults here behave as "no grant in play".
+/// </summary>
+internal static class DelegationTestDoubles
+{
+    /// <summary>A factory that never produces a grant — the shape of an unauthenticated send.</summary>
+    public static IDelegationGrantFactory NoGrantFactory()
+    {
+        var factory = new Mock<IDelegationGrantFactory>();
+        factory.Setup(f => f.CreateForSendAsync(It.IsAny<TimeSpan?>())).ReturnsAsync((string?)null);
+        return factory.Object;
+    }
+
+    /// <summary>A factory that always produces <paramref name="grantId"/>.</summary>
+    public static Mock<IDelegationGrantFactory> GrantFactory(string grantId)
+    {
+        var factory = new Mock<IDelegationGrantFactory>();
+        factory.Setup(f => f.CreateForSendAsync(It.IsAny<TimeSpan?>())).ReturnsAsync(grantId);
+        return factory;
+    }
+
+    public static IDelegationGrantStore NoOpStore() => new Mock<IDelegationGrantStore>().Object;
+
+    public static IDelegatedTokenProvider NoOpProvider() => new Mock<IDelegatedTokenProvider>().Object;
+
+    /// <summary>A well-formed grant id: <c>dg_</c> plus 64 lowercase hex chars.</summary>
+    public static string SampleGrantId(char fill = 'a')
+        => DelegationConstants.GrantIdPrefix + new string(fill, DelegationConstants.GrantIdRandomBytes * 2);
+}

--- a/src/XUnitTest/Delegation/DelegationTokenEndpointResolverTests.cs
+++ b/src/XUnitTest/Delegation/DelegationTokenEndpointResolverTests.cs
@@ -1,0 +1,298 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using System.Text;
+
+namespace XUnitTest.Delegation;
+
+/// <summary>
+/// Section 5.5: discovery first, a complete configured URL as fallback, and a hard startup failure
+/// when neither is present. The path is never guessed.
+/// </summary>
+public class DelegationTokenEndpointResolverTests : IDisposable
+{
+    private const string TenantId = "tenant-1";
+
+    private readonly List<string> _touchedEnvironmentKeys = [];
+
+    public void Dispose()
+    {
+        foreach (var key in _touchedEnvironmentKeys)
+        {
+            Environment.SetEnvironmentVariable(key, null);
+        }
+    }
+
+    private void SetEnvironment(string key, string? value)
+    {
+        _touchedEnvironmentKeys.Add(key);
+        Environment.SetEnvironmentVariable(key, value);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+
+        public List<string> RequestedUrls { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedUrls.Add(request.RequestUri!.ToString());
+            return Task.FromResult(_respond(request));
+        }
+    }
+
+    private static (DelegationTokenEndpointResolver Resolver, StubHandler Handler) CreateResolver(
+        Func<HttpRequestMessage, HttpResponseMessage> respond,
+        IConfiguration? configuration = null)
+    {
+        var handler = new StubHandler(respond);
+        var factory = new Mock<IHttpClientFactory>();
+        factory
+            .Setup(f => f.CreateClient(DelegationConstants.ExchangeHttpClientName))
+            .Returns(() => new HttpClient(handler, disposeHandler: false));
+
+        var resolver = new DelegationTokenEndpointResolver(
+            factory.Object,
+            new Mock<ILogger<DelegationTokenEndpointResolver>>().Object,
+            configuration);
+
+        return (resolver, handler);
+    }
+
+    private static IConfiguration Configuration(params (string Key, string Value)[] values)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(v => new KeyValuePair<string, string?>(v.Key, v.Value)))
+            .Build();
+
+    private static HttpResponseMessage Discovery(string tokenEndpoint)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"token_endpoint\":\"{tokenEndpoint}\"}}", Encoding.UTF8, "application/json")
+        };
+
+    [Fact]
+    public void EnsureConfigured_ShouldThrow_WhenNeitherKeyIsSet()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, null);
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, _) = CreateResolver(_ => Discovery("x"), Configuration());
+
+        var exception = Assert.Throws<InvalidOperationException>(resolver.EnsureConfigured);
+        Assert.Contains(DelegationConstants.IamBaseUrlKey, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(DelegationConstants.IamTokenEndpointKey, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnsureConfigured_ShouldPass_WhenOnlyTheFallbackEndpointIsSet()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, null);
+        var (resolver, _) = CreateResolver(
+            _ => Discovery("x"),
+            Configuration((DelegationConstants.IamTokenEndpointKey, "http://blocks-iam:8080/api/oidc/token")));
+
+        resolver.EnsureConfigured();
+    }
+
+    [Fact]
+    public void EnsureConfigured_ShouldPass_WhenOnlyTheBaseUrlIsSet()
+    {
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+        var (resolver, _) = CreateResolver(
+            _ => Discovery("x"),
+            Configuration((DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080")));
+
+        resolver.EnsureConfigured();
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldUseDiscovery_AndQueryThePerTenantDocument()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080/");
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, handler) = CreateResolver(_ => Discovery("http://blocks-iam:8080/api/oidc/token?tenant_id=tenant-1"));
+
+        var endpoint = await resolver.GetTokenEndpointAsync(TenantId);
+
+        Assert.Equal("http://blocks-iam:8080/api/oidc/token?tenant_id=tenant-1", endpoint);
+        Assert.Equal($"http://blocks-iam:8080/{TenantId}/.well-known/openid-configuration", handler.RequestedUrls.Single());
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldCacheASuccessfulDiscovery()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080");
+        var (resolver, handler) = CreateResolver(_ => Discovery("http://blocks-iam:8080/api/oidc/token"));
+
+        await resolver.GetTokenEndpointAsync(TenantId);
+        await resolver.GetTokenEndpointAsync(TenantId);
+        await resolver.GetTokenEndpointAsync(TenantId);
+
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldFallBackToTheConfiguredUrl_WhenDiscoveryIsUnreachable()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080");
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, _) = CreateResolver(
+            _ => throw new HttpRequestException("connection refused"),
+            Configuration((DelegationConstants.IamTokenEndpointKey, "http://blocks-iam:8080/api/oidc/token")));
+
+        Assert.Equal("http://blocks-iam:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldRetryDiscoveryLazily_AfterUsingTheFallback()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080");
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var attempts = 0;
+        var (resolver, _) = CreateResolver(
+            _ =>
+            {
+                attempts++;
+                if (attempts == 1) throw new HttpRequestException("boot: IAM not up yet");
+                return Discovery("http://blocks-iam:8080/api/oidc/token");
+            },
+            Configuration((DelegationConstants.IamTokenEndpointKey, "http://fallback:8080/api/oidc/token")));
+
+        Assert.Equal("http://fallback:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+        Assert.Equal("http://blocks-iam:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldFallBack_WhenDiscoveryHasNoTokenEndpoint()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080");
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, _) = CreateResolver(
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"issuer\":\"http://blocks-iam:8080\"}", Encoding.UTF8, "application/json")
+            },
+            Configuration((DelegationConstants.IamTokenEndpointKey, "http://blocks-iam:8080/api/oidc/token")));
+
+        Assert.Equal("http://blocks-iam:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldFallBack_WhenDiscoveryReturnsAnErrorStatus()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080");
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, _) = CreateResolver(
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            Configuration((DelegationConstants.IamTokenEndpointKey, "http://blocks-iam:8080/api/oidc/token")));
+
+        Assert.Equal("http://blocks-iam:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldThrow_WhenDiscoveryFailsAndThereIsNoFallback()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://blocks-iam:8080");
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, _) = CreateResolver(_ => throw new HttpRequestException("down"), Configuration());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => resolver.GetTokenEndpointAsync(TenantId));
+        Assert.Contains("Refusing to guess", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldThrow_WithoutATenant()
+    {
+        var (resolver, _) = CreateResolver(_ => Discovery("x"), Configuration());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => resolver.GetTokenEndpointAsync(string.Empty));
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldReadTheFrontendRuntimeSection()
+    {
+        // FrontendRuntime is where Blocks services put runtime settings, so this is the expected home.
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, null);
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, handler) = CreateResolver(
+            _ => Discovery("http://blocks-iam:8080/api/oidc/token"),
+            Configuration(($"{DelegationConstants.FrontendRuntimeSection}:{DelegationConstants.IamBaseUrlKey}", "http://blocks-iam:8080")));
+
+        Assert.Equal("http://blocks-iam:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+        Assert.Single(handler.RequestedUrls);
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldStillReadABareRootLevelKey()
+    {
+        // An appsettings.json that sets the key at the root, outside any section, still resolves.
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, null);
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, handler) = CreateResolver(
+            _ => Discovery("http://from-root:8080/api/oidc/token"),
+            Configuration((DelegationConstants.IamBaseUrlKey, "http://from-root:8080")));
+
+        Assert.Equal("http://from-root:8080/api/oidc/token", await resolver.GetTokenEndpointAsync(TenantId));
+        Assert.StartsWith("http://from-root:8080/", handler.RequestedUrls.Single(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldPreferFrontendRuntimeOverTheConfigurationRoot()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, null);
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, handler) = CreateResolver(
+            _ => Discovery("http://from-section:8080/api/oidc/token"),
+            Configuration(
+                (DelegationConstants.IamBaseUrlKey, "http://from-root:8080"),
+                ($"{DelegationConstants.FrontendRuntimeSection}:{DelegationConstants.IamBaseUrlKey}", "http://from-section:8080")));
+
+        await resolver.GetTokenEndpointAsync(TenantId);
+
+        Assert.StartsWith("http://from-section:8080/", handler.RequestedUrls.Single(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnsureConfigured_ShouldPass_WhenOnlyTheFrontendRuntimeSectionIsSet()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, null);
+        SetEnvironment(DelegationConstants.IamTokenEndpointKey, null);
+
+        var (resolver, _) = CreateResolver(
+            _ => Discovery("x"),
+            Configuration(($"{DelegationConstants.FrontendRuntimeSection}:{DelegationConstants.IamTokenEndpointKey}", "http://blocks-iam:8080/api/oidc/token")));
+
+        resolver.EnsureConfigured();
+    }
+
+    [Fact]
+    public async Task GetTokenEndpointAsync_ShouldPreferTheEnvironmentVariableOverConfiguration()
+    {
+        SetEnvironment(DelegationConstants.IamBaseUrlKey, "http://from-env:8080");
+
+        var (resolver, handler) = CreateResolver(
+            _ => Discovery("http://from-env:8080/api/oidc/token"),
+            Configuration(
+                (DelegationConstants.IamBaseUrlKey, "http://from-config:8080"),
+                ($"{DelegationConstants.FrontendRuntimeSection}:{DelegationConstants.IamBaseUrlKey}", "http://from-section:8080")));
+
+        await resolver.GetTokenEndpointAsync(TenantId);
+
+        Assert.StartsWith("http://from-env:8080/", handler.RequestedUrls.Single(), StringComparison.Ordinal);
+    }
+}

--- a/src/XUnitTest/Message/Azure/AzureMessageClientCoverageTests.cs
+++ b/src/XUnitTest/Message/Azure/AzureMessageClientCoverageTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.Azure;
 
@@ -125,7 +126,10 @@ public class AzureMessageClientCoverageTests
 
     private static AzureMessageClient CreateClient(MessageConfiguration configuration, ActivitySource? activitySource = null)
     {
-        return new AzureMessageClient(configuration, activitySource ?? new ActivitySource("test-azure-client-coverage"));
+        return new AzureMessageClient(
+            configuration,
+            activitySource ?? new ActivitySource("test-azure-client-coverage"),
+            DelegationTestDoubles.NoGrantFactory());
     }
 
     private static AzureMessageClient CreateClientWithInjectedSender(string consumerName, ServiceBusSender sender, ActivitySource activitySource)

--- a/src/XUnitTest/Message/Azure/AzureMessageClientScaffoldTests.cs
+++ b/src/XUnitTest/Message/Azure/AzureMessageClientScaffoldTests.cs
@@ -5,6 +5,7 @@ using OpenTelemetry;
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text.Json;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.Azure;
 
@@ -23,7 +24,7 @@ public class AzureMessageClientScaffoldTests
             }
         };
 
-        var client = new AzureMessageClient(configuration, new System.Diagnostics.ActivitySource("test-azure-client"));
+        var client = new AzureMessageClient(configuration, new System.Diagnostics.ActivitySource("test-azure-client"), DelegationTestDoubles.NoGrantFactory());
 
         var field = typeof(AzureMessageClient).GetField("_senders", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(field);
@@ -168,7 +169,7 @@ public class AzureMessageClientScaffoldTests
             AzureServiceBusConfiguration = new AzureServiceBusConfiguration()
         };
 
-        Assert.Throws<FormatException>(() => new AzureMessageClient(configuration, new System.Diagnostics.ActivitySource("test-azure-client")));
+        Assert.Throws<FormatException>(() => new AzureMessageClient(configuration, new System.Diagnostics.ActivitySource("test-azure-client"), DelegationTestDoubles.NoGrantFactory()));
     }
 
     private static AzureMessageClient CreateClientWithInjectedSender(string consumerName, ServiceBusSender sender)
@@ -183,7 +184,7 @@ public class AzureMessageClientScaffoldTests
             }
         };
 
-        var client = new AzureMessageClient(configuration, new System.Diagnostics.ActivitySource("test-azure-client"));
+        var client = new AzureMessageClient(configuration, new System.Diagnostics.ActivitySource("test-azure-client"), DelegationTestDoubles.NoGrantFactory());
 
         var field = typeof(AzureMessageClient).GetField("_senders", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(field);

--- a/src/XUnitTest/Message/Azure/AzureMessageWorkerCoverageTests.cs
+++ b/src/XUnitTest/Message/Azure/AzureMessageWorkerCoverageTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.Azure;
 
@@ -497,7 +498,9 @@ public class AzureMessageWorkerCoverageTests
             logger.Object,
             configuration,
             consumer,
-            new ActivitySource(activitySourceName ?? "test-azure-worker-coverage"));
+            new ActivitySource(activitySourceName ?? "test-azure-worker-coverage"),
+            DelegationTestDoubles.NoOpStore(),
+            DelegationTestDoubles.NoOpProvider());
     }
 
     private static ServiceBusReceivedMessage CreateReceivedMessage(string messageId, string body, IDictionary<string, object>? properties = null)

--- a/src/XUnitTest/Message/Azure/AzureMessageWorkerScaffoldTests.cs
+++ b/src/XUnitTest/Message/Azure/AzureMessageWorkerScaffoldTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.Azure;
 
@@ -239,7 +240,9 @@ public class AzureMessageWorkerScaffoldTests
             logger.Object,
             config,
             consumer,
-            new System.Diagnostics.ActivitySource("test-azure-worker"));
+            new System.Diagnostics.ActivitySource("test-azure-worker"),
+            DelegationTestDoubles.NoOpStore(),
+            DelegationTestDoubles.NoOpProvider());
 
         var exception = await Record.ExceptionAsync(() => worker.StopAsync(CancellationToken.None));
 
@@ -261,7 +264,7 @@ public class AzureMessageWorkerScaffoldTests
             AzureServiceBusConfiguration = new AzureServiceBusConfiguration()
         };
 
-        var ex = Record.Exception(() => new AzureMessageWorker(logger.Object, config, consumer, new ActivitySource("test")));
+        var ex = Record.Exception(() => new AzureMessageWorker(logger.Object, config, consumer, new ActivitySource("test"), DelegationTestDoubles.NoOpStore(), DelegationTestDoubles.NoOpProvider()));
 
         Assert.Null(ex);
     }
@@ -280,7 +283,7 @@ public class AzureMessageWorkerScaffoldTests
             AzureServiceBusConfiguration = new AzureServiceBusConfiguration()
         };
 
-        var ex = Record.Exception(() => new AzureMessageWorker(logger.Object, config, consumer, new ActivitySource("test")));
+        var ex = Record.Exception(() => new AzureMessageWorker(logger.Object, config, consumer, new ActivitySource("test"), DelegationTestDoubles.NoOpStore(), DelegationTestDoubles.NoOpProvider()));
 
         Assert.Null(ex);
     }
@@ -330,7 +333,9 @@ public class AzureMessageWorkerScaffoldTests
             logger.Object,
             configuration,
             consumer,
-            new ActivitySource("test-azure-worker"));
+            new ActivitySource("test-azure-worker"),
+            DelegationTestDoubles.NoOpStore(),
+            DelegationTestDoubles.NoOpProvider());
     }
 
     private static async Task InvokePrivateAsync(object instance, string methodName, params object[] args)

--- a/src/XUnitTest/Message/RabbitMq/RabbitMessageClientCoverageTests.cs
+++ b/src/XUnitTest/Message/RabbitMq/RabbitMessageClientCoverageTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using RabbitMQ.Client;
 using System.Diagnostics;
 using System.Reflection;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.RabbitMq;
 
@@ -254,7 +255,8 @@ public class RabbitMessageClientCoverageTests
             logger,
             rabbitService,
             configuration,
-            new ActivitySource("test-rabbit-client-coverage"));
+            new ActivitySource("test-rabbit-client-coverage"),
+            DelegationTestDoubles.NoGrantFactory());
     }
 
     private static MessageConfiguration CreateConfiguration()

--- a/src/XUnitTest/Message/RabbitMq/RabbitMessageClientScaffoldTests.cs
+++ b/src/XUnitTest/Message/RabbitMq/RabbitMessageClientScaffoldTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RabbitMQ.Client;
 using System.Diagnostics;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.RabbitMq;
 
@@ -20,7 +21,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
@@ -55,7 +57,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
         {
@@ -97,7 +100,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await client.SendToMassConsumerAsync(new ConsumerMessage<TestPayload>
         {
@@ -149,7 +153,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
             client.SendToConsumerAsync<TestPayload>(null!));
@@ -179,7 +184,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfigurationWithoutTtl(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
         {
@@ -221,7 +227,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         var customContext = "{\"TenantId\":\"custom-tenant\"}";
         await client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
@@ -264,7 +271,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         var ex = await Record.ExceptionAsync(() => client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
         {
@@ -300,7 +308,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
         {
@@ -334,7 +343,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
@@ -369,7 +379,8 @@ public class RabbitMessageClientScaffoldTests
             logger.Object,
             rabbitService.Object,
             CreateMessageConfiguration(),
-            new ActivitySource("test-rabbit-client"));
+            new ActivitySource("test-rabbit-client"),
+            DelegationTestDoubles.NoGrantFactory());
 
         await client.SendToConsumerAsync(new ConsumerMessage<TestPayload>
         {

--- a/src/XUnitTest/Message/RabbitMq/RabbitMessageWorkerCoverageTests.cs
+++ b/src/XUnitTest/Message/RabbitMq/RabbitMessageWorkerCoverageTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.RabbitMq;
 
@@ -373,7 +374,7 @@ public class RabbitMessageWorkerCoverageTests
 
         var ea = CreateEventArgs("orders.queue", "not-json", deliveryTag: 181);
 
-        await InvokePrivateAsync(worker, "DispatchAndAckAsync", [Encoding.UTF8.GetBytes("not-json"), null, ea]);
+        await InvokePrivateAsync(worker, "DispatchAndAckAsync", [Encoding.UTF8.GetBytes("not-json"), null, ea, null]);
 
         channel.Verify(x => x.BasicAckAsync(181, false, It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -616,7 +617,9 @@ public class RabbitMessageWorkerCoverageTests
             configuration,
             rabbitService,
             consumer,
-            new ActivitySource("test-worker-coverage"));
+            new ActivitySource("test-worker-coverage"),
+            DelegationTestDoubles.NoOpStore(),
+            DelegationTestDoubles.NoOpProvider());
     }
 
     private static MessageConfiguration CreateConfiguration(string queueName)

--- a/src/XUnitTest/Message/RabbitMq/RabbitMessageWorkerScaffoldTests.cs
+++ b/src/XUnitTest/Message/RabbitMq/RabbitMessageWorkerScaffoldTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using XUnitTest.Delegation;
 
 namespace XUnitTest.Message.RabbitMq;
 
@@ -66,10 +67,11 @@ public class RabbitMessageWorkerScaffoldTests
             ["TraceId"] = Encoding.UTF8.GetBytes("0123456789abcdef0123456789abcdef"),
             ["SpanId"] = Encoding.UTF8.GetBytes("0123456789abcdef"),
             ["SecurityContext"] = Encoding.UTF8.GetBytes("{}"),
-            ["Baggage"] = Encoding.UTF8.GetBytes("{\"k\":\"v\"}")
+            ["Baggage"] = Encoding.UTF8.GetBytes("{\"k\":\"v\"}"),
+            ["DelegationGrant"] = Encoding.UTF8.GetBytes("dg_" + new string('a', 64))
         });
 
-        object?[] args = [props.Object, null, null, null, null, null];
+        object?[] args = [props.Object, null, null, null, null, null, null];
         method!.Invoke(null, args);
 
         Assert.Equal("tenant-2", args[1]);
@@ -77,6 +79,26 @@ public class RabbitMessageWorkerScaffoldTests
         Assert.Equal("0123456789abcdef", args[3]);
         Assert.Equal("{}", args[4]);
         Assert.Equal("{\"k\":\"v\"}", args[5]);
+        Assert.Equal("dg_" + new string('a', 64), args[6]);
+    }
+
+    [Fact]
+    public void ExtractHeaders_ShouldReturnNullDelegationGrant_WhenTheHeaderIsAbsent()
+    {
+        var method = typeof(RabbitMessageWorker).GetMethod("ExtractHeaders", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var props = new Mock<IReadOnlyBasicProperties>();
+        props.SetupGet(x => x.Headers).Returns(new Dictionary<string, object?>
+        {
+            ["TenantId"] = Encoding.UTF8.GetBytes("tenant-2")
+        });
+
+        object?[] args = [props.Object, null, null, null, null, null, null];
+        method!.Invoke(null, args);
+
+        // A message sent without an authenticated user carries no grant.
+        Assert.Null(args[6]);
     }
 
     [Fact]
@@ -96,7 +118,9 @@ public class RabbitMessageWorkerScaffoldTests
             new MessageConfiguration { RabbitMqConfiguration = new RabbitMqConfiguration() },
             rabbitService.Object,
             consumer,
-            new System.Diagnostics.ActivitySource("test-worker"));
+            new System.Diagnostics.ActivitySource("test-worker"),
+            DelegationTestDoubles.NoOpStore(),
+            DelegationTestDoubles.NoOpProvider());
 
         var field = typeof(RabbitMessageWorker).GetField("_channel", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(field);
@@ -272,7 +296,9 @@ public class RabbitMessageWorkerScaffoldTests
             configuration,
             rabbitService,
             consumer,
-            new ActivitySource("test-worker"));
+            new ActivitySource("test-worker"),
+            DelegationTestDoubles.NoOpStore(),
+            DelegationTestDoubles.NoOpProvider());
     }
 
     private static MessageConfiguration CreateConfiguration(string queueName)


### PR DESCRIPTION
- Implemented DelegationGrantStoreTests to cover creation, retrieval, and deletion of delegation grants.
- Added DelegationMessageFlowTests for end-to-end testing of Azure and RabbitMQ message flows, ensuring proper handling of delegation grants.
- Introduced DelegationTestDoubles for mocking dependencies in tests.
- Created DelegationTokenEndpointResolverTests to validate token endpoint resolution logic, including discovery and fallback mechanisms.